### PR TITLE
feat(heimdall): add branch-serial multi-variant batch run

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,8 +292,11 @@ Key rules:
 - no public `provider.*` host-path block is allowed
 - do not put secrets such as `SONAR_TOKEN` in the manifest
 - unknown top-level keys are rejected
-- `eitri.writers` is passed through directly to Eitri, so nested keys must match
-  Eitri's real PlantUML config schema such as `diagramName` or `hidePrivate`
+- `eitri.writers` is passed through to original `eitri`, but Heimdall forces
+  `writers.plantuml.generateDegradedDiagrams: false` for `eitri-generated*` so
+  generated-repo Eitri runs emit only `diagram.puml`
+- nested `eitri.writers` keys must still match Eitri's real PlantUML config
+  schema such as `diagramName`, `hidePrivate`, or `generateDegradedDiagrams`
 
 ## Run layout
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # Heimdall
 
-Heimdall is the host-side orchestrator for the fixed pipeline graph:
+Heimdall is the host-side orchestrator for a fixed branch-serial DAG:
 
 1. `Brokk`
 2. then in parallel: `Eitri`, `Lidskjalv(original)`
-3. then `Andvari`
-4. then in parallel: `Eitri(generated)`, `Kvasir`
-5. then `Lidskjalv(generated)` scans Kvasir's finished repo with ported tests
-6. then `Mimir` compares the original and generated Eitri snapshots
+3. then the best-effort generated branch:
+   `Andvari -> Eitri(generated) -> Mimir` and `Andvari -> Kvasir -> Lidskjalv(generated)`
+4. then the `v2` generated branch with the same shape
+5. then the `v3` generated branch with the same shape
 
-`Kvasir` fans out after `Andvari`, `Lidskjalv(generated)` waits for Kvasir's
-ported-tests artifact, and neither step waits for `Mimir`.
+The best-effort, `v2`, and `v3` generated branches all live under the same
+Heimdall run and share one `run_id`. Later branches wait only for the prior
+branch to reach a terminal state; they do not require the prior branch to pass.
+
+Within a branch, `Mimir` starts after `Eitri(generated*)` and compares the
+original Eitri `diagram.puml` against that branch's generated `diagram.puml`.
+`Kvasir` and `Lidskjalv(generated*)` are independent of `Mimir`.
 
 It uses the Docker CLI through `subprocess`, renders one service-specific
 manifest per step, stores run state under `runs/<run_id>/`, and branches on
@@ -64,6 +69,11 @@ mounts.
 Heimdall can also run as a long-lived VPS worker that owns a FIFO queue. The
 queue uses YAML request/job records under `queue/`, while the canonical
 pipeline outputs remain under `runs/<run_id>/`.
+
+Each queued `(repo_url, commit_sha)` becomes one queue job and one Heimdall
+run. The worker uses the allocated `job_id` as the pipeline `run_id`, so a
+single repo/commit produces one run directory containing the best-effort, `v2`,
+and `v3` branches together.
 
 Worker config example:
 
@@ -295,17 +305,31 @@ Each run is written under `runs/<run_id>/`:
 - `pipeline/artifact_index.json`
 - `pipeline/outputs/run_report.json`
 - `pipeline/outputs/summary.md`
+- `pipeline/outputs/sonar_follow_up.json`
 - `pipeline/logs/<step>.log`
 - `services/<step>/config/manifest.yaml`
 - `services/<step>/run/...`
+
+For one queued repo/commit, the run contains service directories for:
+
+- original/source steps: `brokk`, `eitri`, `lidskjalv-original`
+- best-effort generated branch: `andvari`, `eitri-generated`, `mimir`, `kvasir`, `lidskjalv-generated`
+- `v2` generated branch: `andvari-v2`, `eitri-generated-v2`, `mimir-v2`, `kvasir-v2`, `lidskjalv-generated-v2`
+- `v3` generated branch: `andvari-v3`, `eitri-generated-v3`, `mimir-v3`, `kvasir-v3`, `lidskjalv-generated-v3`
+
+The per-step container logs are all written under the same run at
+`pipeline/logs/<step>.log`, for example `andvari.log`, `andvari-v2.log`, and
+`mimir-v3.log`.
 
 Service `run/` directories are created with mode `0777` so the service images
 can write as `uid=10001` on both local hosts and the `munin` VPS user.
 
 Pipeline reports may now include top-level `repository_stats` and
-`diagram_comparisons`. The artifact index may include `model_snapshot`,
-`generated_model_snapshot`, `mimir_report`, and `diagram_comparison_*` entries
-when those artifacts are produced by the run.
+`diagram_comparisons` aggregated across `mimir`, `mimir-v2`, and `mimir-v3`.
+The artifact index may include best-effort keys such as `mimir_report` and
+`diagram_comparison_*`, plus suffixed branch keys such as `generated_repo_v2`,
+`ported_tests_repo_v3`, `mimir_v2_report`, and
+`lidskjalv_generated_v3_report`.
 
 With `--verbose`, Heimdall prints preflight progress, step start/finish events,
 and streams each container's combined stdout/stderr to the terminal with a step

--- a/src/heimdall/adapters.py
+++ b/src/heimdall/adapters.py
@@ -552,26 +552,14 @@ def _andvari_generated_repo_for_kvasir_step(run_root: Path, step: str) -> Path:
 
 def _andvari_generated_repo_for_branch_suffix(run_root: Path, suffix: str) -> Path:
     service_dir = "andvari" if suffix == "" else f"andvari-{suffix}"
-    return (
-        run_root
-        / "services"
-        / service_dir
-        / "run"
-        / "artifacts"
-        / "generated-repo"
-    )
+    return run_root / "services" / service_dir / "run" / "artifacts" / "generated-repo"
 
 
 def _kvasir_ported_tests_repo_for_lidskjalv_step(run_root: Path, step: str) -> Path:
     suffix = _branch_suffix(step)
     service_dir = "kvasir" if suffix == "" else f"kvasir-{suffix}"
     return (
-        run_root
-        / "services"
-        / service_dir
-        / "run"
-        / "artifacts"
-        / "ported-tests-repo"
+        run_root / "services" / service_dir / "run" / "artifacts" / "ported-tests-repo"
     )
 
 

--- a/src/heimdall/adapters.py
+++ b/src/heimdall/adapters.py
@@ -8,18 +8,28 @@ from pathlib import Path
 from heimdall.manifests.services import (
     build_step_manifest_payload,
     build_step_runtime_hints,
-    mimir_snapshot_sources,
+    mimir_diagram_sources,
 )
 from heimdall.models import (
     ALL_STEPS,
     STEP_ANDVARI,
+    STEP_ANDVARI_V2,
+    STEP_ANDVARI_V3,
     STEP_BROKK,
     STEP_EITRI,
     STEP_EITRI_GENERATED,
+    STEP_EITRI_GENERATED_V2,
+    STEP_EITRI_GENERATED_V3,
     STEP_KVASIR,
+    STEP_KVASIR_V2,
+    STEP_KVASIR_V3,
     STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
     STEP_LIDSKJALV_ORIGINAL,
     STEP_MIMIR,
+    STEP_MIMIR_V2,
+    STEP_MIMIR_V3,
     ArtifactRecord,
     DockerMount,
     PipelineConfig,
@@ -42,6 +52,21 @@ class AdapterContext:
     resolved_images: ResolvedImages
 
 
+ANDVARI_STEPS = (STEP_ANDVARI, STEP_ANDVARI_V2, STEP_ANDVARI_V3)
+EITRI_GENERATED_STEPS = (
+    STEP_EITRI_GENERATED,
+    STEP_EITRI_GENERATED_V2,
+    STEP_EITRI_GENERATED_V3,
+)
+KVASIR_STEPS = (STEP_KVASIR, STEP_KVASIR_V2, STEP_KVASIR_V3)
+MIMIR_STEPS = (STEP_MIMIR, STEP_MIMIR_V2, STEP_MIMIR_V3)
+LIDSKJALV_GENERATED_STEPS = (
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
+
+
 STEP_DEFINITIONS: dict[str, StepDefinition] = {
     STEP_BROKK: StepDefinition(
         name=STEP_BROKK,
@@ -61,6 +86,18 @@ STEP_DEFINITIONS: dict[str, StepDefinition] = {
         service_dir_name="eitri-generated",
         report_relative_path="outputs/run_report.json",
     ),
+    STEP_EITRI_GENERATED_V2: StepDefinition(
+        name=STEP_EITRI_GENERATED_V2,
+        depends_on=(STEP_ANDVARI_V2,),
+        service_dir_name="eitri-generated-v2",
+        report_relative_path="outputs/run_report.json",
+    ),
+    STEP_EITRI_GENERATED_V3: StepDefinition(
+        name=STEP_EITRI_GENERATED_V3,
+        depends_on=(STEP_ANDVARI_V3,),
+        service_dir_name="eitri-generated-v3",
+        report_relative_path="outputs/run_report.json",
+    ),
     STEP_LIDSKJALV_ORIGINAL: StepDefinition(
         name=STEP_LIDSKJALV_ORIGINAL,
         depends_on=(STEP_BROKK,),
@@ -73,10 +110,36 @@ STEP_DEFINITIONS: dict[str, StepDefinition] = {
         service_dir_name="andvari",
         report_relative_path="outputs/run_report.json",
     ),
+    STEP_ANDVARI_V2: StepDefinition(
+        name=STEP_ANDVARI_V2,
+        depends_on=(STEP_EITRI,),
+        service_dir_name="andvari-v2",
+        report_relative_path="outputs/run_report.json",
+        order_after=(STEP_MIMIR, STEP_LIDSKJALV_GENERATED),
+    ),
+    STEP_ANDVARI_V3: StepDefinition(
+        name=STEP_ANDVARI_V3,
+        depends_on=(STEP_EITRI,),
+        service_dir_name="andvari-v3",
+        report_relative_path="outputs/run_report.json",
+        order_after=(STEP_MIMIR_V2, STEP_LIDSKJALV_GENERATED_V2),
+    ),
     STEP_MIMIR: StepDefinition(
         name=STEP_MIMIR,
         depends_on=(STEP_EITRI, STEP_EITRI_GENERATED),
         service_dir_name="mimir",
+        report_relative_path="outputs/run_report.json",
+    ),
+    STEP_MIMIR_V2: StepDefinition(
+        name=STEP_MIMIR_V2,
+        depends_on=(STEP_EITRI, STEP_EITRI_GENERATED_V2),
+        service_dir_name="mimir-v2",
+        report_relative_path="outputs/run_report.json",
+    ),
+    STEP_MIMIR_V3: StepDefinition(
+        name=STEP_MIMIR_V3,
+        depends_on=(STEP_EITRI, STEP_EITRI_GENERATED_V3),
+        service_dir_name="mimir-v3",
         report_relative_path="outputs/run_report.json",
     ),
     STEP_KVASIR: StepDefinition(
@@ -85,10 +148,34 @@ STEP_DEFINITIONS: dict[str, StepDefinition] = {
         service_dir_name="kvasir",
         report_relative_path="outputs/test_port.json",
     ),
+    STEP_KVASIR_V2: StepDefinition(
+        name=STEP_KVASIR_V2,
+        depends_on=(STEP_BROKK, STEP_EITRI, STEP_ANDVARI_V2),
+        service_dir_name="kvasir-v2",
+        report_relative_path="outputs/test_port.json",
+    ),
+    STEP_KVASIR_V3: StepDefinition(
+        name=STEP_KVASIR_V3,
+        depends_on=(STEP_BROKK, STEP_EITRI, STEP_ANDVARI_V3),
+        service_dir_name="kvasir-v3",
+        report_relative_path="outputs/test_port.json",
+    ),
     STEP_LIDSKJALV_GENERATED: StepDefinition(
         name=STEP_LIDSKJALV_GENERATED,
         depends_on=(STEP_KVASIR,),
         service_dir_name="lidskjalv-generated",
+        report_relative_path="outputs/run_report.json",
+    ),
+    STEP_LIDSKJALV_GENERATED_V2: StepDefinition(
+        name=STEP_LIDSKJALV_GENERATED_V2,
+        depends_on=(STEP_KVASIR_V2,),
+        service_dir_name="lidskjalv-generated-v2",
+        report_relative_path="outputs/run_report.json",
+    ),
+    STEP_LIDSKJALV_GENERATED_V3: StepDefinition(
+        name=STEP_LIDSKJALV_GENERATED_V3,
+        depends_on=(STEP_KVASIR_V3,),
+        service_dir_name="lidskjalv-generated-v3",
         report_relative_path="outputs/run_report.json",
     ),
 }
@@ -133,13 +220,13 @@ def prepare_step(
         )
         image_ref = context.config.images.brokk
         resolved_image_id = context.resolved_images.brokk
-    elif step in {STEP_EITRI, STEP_EITRI_GENERATED}:
+    elif step in {STEP_EITRI, *EITRI_GENERATED_STEPS}:
         payload = build_step_manifest_payload(step, context)
         env = {"EITRI_MANIFEST": "/run/config/manifest.yaml"}
         input_repo = (
             _brokk_original_repo(context.run_root)
             if step == STEP_EITRI
-            else _andvari_generated_repo(context.run_root)
+            else _andvari_generated_repo_for_eitri_step(context.run_root, step)
         )
         mounts = (
             DockerMount(input_repo, "/input/repo", True),
@@ -148,12 +235,12 @@ def prepare_step(
         )
         image_ref = context.config.images.eitri
         resolved_image_id = context.resolved_images.eitri
-    elif step == STEP_ANDVARI:
+    elif step in ANDVARI_STEPS:
         payload = build_step_manifest_payload(step, context)
         input_model_dir = service_root / "input" / "model"
         ensure_directory(input_model_dir, 0o755)
         if stage_inputs:
-            source_diagram = _eitri_diagram(context.run_root)
+            source_diagram = _eitri_diagram_for_andvari_step(context.run_root, step)
             destination_diagram = input_model_dir / "diagram.puml"
             shutil.copy2(source_diagram, destination_diagram)
             destination_diagram.chmod(0o644)
@@ -173,8 +260,15 @@ def prepare_step(
         provider_bin_dest = provider_bin_dir
         provider_seed_source = context.runtime.codex_home_dir
         provider_seed_dest = provider_seed_dir
-    elif step == STEP_KVASIR:
+    elif step in KVASIR_STEPS:
         payload = build_step_manifest_payload(step, context)
+        input_model_dir = service_root / "input" / "model"
+        ensure_directory(input_model_dir, 0o755)
+        if stage_inputs:
+            source_diagram = _eitri_diagram_for_kvasir_step(context.run_root, step)
+            destination_diagram = input_model_dir / "diagram.puml"
+            shutil.copy2(source_diagram, destination_diagram)
+            destination_diagram.chmod(0o644)
         provider_bin_dir = service_root / "input" / "provider-bin"
         provider_seed_dir = service_root / "input" / "provider-seed"
         env = {
@@ -186,9 +280,11 @@ def prepare_step(
                 _brokk_original_repo(context.run_root), "/input/original-repo", True
             ),
             DockerMount(
-                _andvari_generated_repo(context.run_root), "/input/generated-repo", True
+                _andvari_generated_repo_for_kvasir_step(context.run_root, step),
+                "/input/generated-repo",
+                True,
             ),
-            DockerMount(_eitri_model_dir(context.run_root), "/input/model", True),
+            DockerMount(input_model_dir, "/input/model", True),
             DockerMount(config_dir, "/run/config", True),
             DockerMount(run_dir, "/run", False),
             DockerMount(provider_bin_dir, "/opt/provider/bin", True),
@@ -200,13 +296,15 @@ def prepare_step(
         provider_bin_dest = provider_bin_dir
         provider_seed_source = context.runtime.codex_home_dir
         provider_seed_dest = provider_seed_dir
-    elif step == STEP_MIMIR:
+    elif step in MIMIR_STEPS:
         payload = build_step_manifest_payload(step, context)
-        input_snapshots_dir = run_dir / "inputs" / "snapshots"
-        ensure_directory(input_snapshots_dir, 0o755)
+        input_diagrams_dir = run_dir / "inputs" / "diagrams"
+        ensure_directory(input_diagrams_dir, 0o755)
         if stage_inputs:
-            for label, source_path in mimir_snapshot_sources(context.run_root).items():
-                destination = input_snapshots_dir / label / "model_snapshot.json"
+            for label, source_path in mimir_diagram_sources(
+                step, context.run_root
+            ).items():
+                destination = input_diagrams_dir / label / "diagram.puml"
                 ensure_directory(destination.parent, 0o755)
                 shutil.copy2(source_path, destination)
                 destination.chmod(0o644)
@@ -218,7 +316,7 @@ def prepare_step(
         image_ref = context.config.images.mimir
         resolved_image_id = context.resolved_images.mimir
     else:
-        generated = step == STEP_LIDSKJALV_GENERATED
+        generated = step in LIDSKJALV_GENERATED_STEPS
         payload = build_step_manifest_payload(step, context)
         env = {"LIDSKJALV_MANIFEST": "/run/config/manifest.yaml"}
         if not context.config.lidskjalv.skip_sonar:
@@ -230,7 +328,7 @@ def prepare_step(
             if context.runtime.sonar_organization is not None:
                 env["SONAR_ORGANIZATION"] = context.runtime.sonar_organization
         input_repo = (
-            _kvasir_ported_tests_repo(context.run_root)
+            _kvasir_ported_tests_repo_for_lidskjalv_step(context.run_root, step)
             if generated
             else _brokk_original_repo(context.run_root)
         )
@@ -244,7 +342,7 @@ def prepare_step(
 
     manifest_text = dumps(payload)
     write_text(config_path, manifest_text)
-    if step == STEP_KVASIR:
+    if step in KVASIR_STEPS:
         build_hints_path = config_dir / "build-hints.json"
         build_hints = build_step_runtime_hints(step, context)
         if build_hints:
@@ -287,7 +385,7 @@ def classify_report(
 
 
 def _is_success(step: str, report: dict[str, object]) -> bool:
-    if step == STEP_KVASIR:
+    if step in KVASIR_STEPS:
         return (
             report.get("status") == "passed"
             and report.get("behavioral_verdict") == "pass"
@@ -300,7 +398,7 @@ def _classify_reason(step: str, report: dict[str, object]) -> str | None:
     if reason:
         return str(reason)
     if (
-        step == STEP_KVASIR
+        step in KVASIR_STEPS
         and report.get("status") == "passed"
         and report.get("behavioral_verdict") != "pass"
     ):
@@ -339,48 +437,55 @@ def _artifact_records(step: str, report_path: Path) -> dict[str, ArtifactRecord]
             records["model_repository_stats"] = ArtifactRecord(
                 owner=step, path=str(repository_stats)
             )
-    elif step == STEP_EITRI_GENERATED:
+    elif step in EITRI_GENERATED_STEPS:
+        suffix = _artifact_key_suffix(step)
         diagram = run_dir / "artifacts" / "model" / "diagram.puml"
         model_snapshot = run_dir / "artifacts" / "model" / "model_snapshot.json"
         logs_dir = run_dir / "artifacts" / "model" / "logs"
         repository_stats = run_dir / "artifacts" / "model" / "repository_stats.json"
         if diagram.exists():
-            records["generated_model_diagram"] = ArtifactRecord(
+            records[f"generated_model_diagram{suffix}"] = ArtifactRecord(
                 owner=step, path=str(diagram)
             )
         if model_snapshot.exists():
-            records["generated_model_snapshot"] = ArtifactRecord(
+            records[f"generated_model_snapshot{suffix}"] = ArtifactRecord(
                 owner=step, path=str(model_snapshot)
             )
         if logs_dir.exists():
-            records["generated_model_logs"] = ArtifactRecord(
+            records[f"generated_model_logs{suffix}"] = ArtifactRecord(
                 owner=step, path=str(logs_dir)
             )
         if repository_stats.exists():
-            records["generated_model_repository_stats"] = ArtifactRecord(
+            records[f"generated_model_repository_stats{suffix}"] = ArtifactRecord(
                 owner=step, path=str(repository_stats)
             )
-    elif step == STEP_ANDVARI:
+    elif step in ANDVARI_STEPS:
+        suffix = _artifact_key_suffix(step)
         generated_repo = run_dir / "artifacts" / "generated-repo"
         logs_dir = run_dir / "artifacts" / "andvari" / "logs"
         report_dir = run_dir / "artifacts" / "andvari" / "report"
         if generated_repo.exists():
-            records["generated_repo"] = ArtifactRecord(
+            records[f"generated_repo{suffix}"] = ArtifactRecord(
                 owner=step, path=str(generated_repo)
             )
         if logs_dir.exists():
-            records["andvari_logs"] = ArtifactRecord(owner=step, path=str(logs_dir))
+            records[f"andvari_logs{suffix}"] = ArtifactRecord(
+                owner=step, path=str(logs_dir)
+            )
         if report_dir.exists():
-            records["andvari_report_dir"] = ArtifactRecord(
+            records[f"andvari_report_dir{suffix}"] = ArtifactRecord(
                 owner=step, path=str(report_dir)
             )
-    elif step == STEP_MIMIR:
-        records["mimir_report"] = ArtifactRecord(owner=step, path=str(report_path))
+    elif step in MIMIR_STEPS:
+        suffix = _artifact_key_suffix(step)
+        records[f"mimir{suffix}_report"] = ArtifactRecord(
+            owner=step, path=str(report_path)
+        )
         comparison_dir = run_dir / "artifacts" / "comparisons"
         if comparison_dir.exists():
             aggregate_path = comparison_dir / "aggregate.json"
             if aggregate_path.exists():
-                records["diagram_comparison_aggregate"] = ArtifactRecord(
+                records[f"diagram_comparison_aggregate{suffix}"] = ArtifactRecord(
                     owner=step, path=str(aggregate_path)
                 )
             for artifact_path in sorted(comparison_dir.glob("*.json")):
@@ -389,19 +494,23 @@ def _artifact_records(step: str, report_path: Path) -> dict[str, ArtifactRecord]
                 records[f"diagram_comparison_{artifact_path.stem}"] = ArtifactRecord(
                     owner=step, path=str(artifact_path)
                 )
-    elif step == STEP_KVASIR:
-        records["kvasir_report"] = ArtifactRecord(owner=step, path=str(report_path))
+    elif step in KVASIR_STEPS:
+        suffix = _artifact_key_suffix(step)
+        records[f"kvasir{suffix}_report"] = ArtifactRecord(
+            owner=step, path=str(report_path)
+        )
         ported_repo = run_dir / "artifacts" / "ported-tests-repo"
         if ported_repo.exists():
-            records["ported_tests_repo"] = ArtifactRecord(
+            records[f"ported_tests_repo{suffix}"] = ArtifactRecord(
                 owner=step, path=str(ported_repo)
             )
     elif step == STEP_LIDSKJALV_ORIGINAL:
         records["lidskjalv_original_report"] = ArtifactRecord(
             owner=step, path=str(report_path)
         )
-    elif step == STEP_LIDSKJALV_GENERATED:
-        records["lidskjalv_generated_report"] = ArtifactRecord(
+    elif step in LIDSKJALV_GENERATED_STEPS:
+        suffix = _artifact_key_suffix(step)
+        records[f"lidskjalv_generated{suffix}_report"] = ArtifactRecord(
             owner=step, path=str(report_path)
         )
     return records
@@ -421,22 +530,71 @@ def _brokk_original_repo(run_root: Path) -> Path:
     return run_root / "services" / "brokk" / "run" / "artifacts" / "original-repo"
 
 
-def _eitri_diagram(run_root: Path) -> Path:
+def _eitri_diagram_variant(run_root: Path, filename: str) -> Path:
+    return run_root / "services" / "eitri" / "run" / "artifacts" / "model" / filename
+
+
+def _eitri_diagram_for_andvari_step(run_root: Path, step: str) -> Path:
+    return _eitri_diagram_variant(run_root, _diagram_filename_for_branch_step(step))
+
+
+def _eitri_diagram_for_kvasir_step(run_root: Path, step: str) -> Path:
+    return _eitri_diagram_variant(run_root, _diagram_filename_for_branch_step(step))
+
+
+def _andvari_generated_repo_for_eitri_step(run_root: Path, step: str) -> Path:
+    return _andvari_generated_repo_for_branch_suffix(run_root, _branch_suffix(step))
+
+
+def _andvari_generated_repo_for_kvasir_step(run_root: Path, step: str) -> Path:
+    return _andvari_generated_repo_for_branch_suffix(run_root, _branch_suffix(step))
+
+
+def _andvari_generated_repo_for_branch_suffix(run_root: Path, suffix: str) -> Path:
+    service_dir = "andvari" if suffix == "" else f"andvari-{suffix}"
     return (
-        run_root / "services" / "eitri" / "run" / "artifacts" / "model" / "diagram.puml"
+        run_root
+        / "services"
+        / service_dir
+        / "run"
+        / "artifacts"
+        / "generated-repo"
     )
 
 
-def _eitri_model_dir(run_root: Path) -> Path:
-    return run_root / "services" / "eitri" / "run" / "artifacts" / "model"
+def _kvasir_ported_tests_repo_for_lidskjalv_step(run_root: Path, step: str) -> Path:
+    suffix = _branch_suffix(step)
+    service_dir = "kvasir" if suffix == "" else f"kvasir-{suffix}"
+    return (
+        run_root
+        / "services"
+        / service_dir
+        / "run"
+        / "artifacts"
+        / "ported-tests-repo"
+    )
 
 
-def _andvari_generated_repo(run_root: Path) -> Path:
-    return run_root / "services" / "andvari" / "run" / "artifacts" / "generated-repo"
+def _diagram_filename_for_branch_step(step: str) -> str:
+    suffix = _branch_suffix(step)
+    if suffix == "v2":
+        return "diagram_v2.puml"
+    if suffix == "v3":
+        return "diagram_v3.puml"
+    return "diagram.puml"
 
 
-def _kvasir_ported_tests_repo(run_root: Path) -> Path:
-    return run_root / "services" / "kvasir" / "run" / "artifacts" / "ported-tests-repo"
+def _branch_suffix(step: str) -> str:
+    if step.endswith("-v2"):
+        return "v2"
+    if step.endswith("-v3"):
+        return "v3"
+    return ""
+
+
+def _artifact_key_suffix(step: str) -> str:
+    suffix = _branch_suffix(step)
+    return f"_{suffix}" if suffix else ""
 
 
 def _sonar_token() -> str | None:

--- a/src/heimdall/manifests/services.py
+++ b/src/heimdall/manifests/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -68,8 +69,11 @@ def build_step_manifest_payload(
             payload["writer_extension"] = context.config.eitri.writer_extension
         if context.config.eitri.verbose:
             payload["verbose"] = True
-        if context.config.eitri.writers:
-            payload["writers"] = context.config.eitri.writers
+        writers: Mapping[str, object] = context.config.eitri.writers
+        if step in EITRI_GENERATED_STEPS:
+            payload["writers"] = _generated_eitri_writers(writers)
+        elif writers:
+            payload["writers"] = dict(writers)
         return payload
     if step in ANDVARI_STEPS:
         return {
@@ -287,6 +291,19 @@ def _service_dir_for_step(step: str) -> str:
         STEP_LIDSKJALV_GENERATED_V2: "lidskjalv-generated-v2",
         STEP_LIDSKJALV_GENERATED_V3: "lidskjalv-generated-v3",
     }[step]
+
+
+def _generated_eitri_writers(configured: Mapping[str, object]) -> dict[str, object]:
+    writers: dict[str, object] = copy.deepcopy(dict(configured))
+    plantuml = writers.get("plantuml")
+    if plantuml is None:
+        writers["plantuml"] = {"generateDegradedDiagrams": False}
+        return writers
+    if isinstance(plantuml, Mapping):
+        plantuml_config = copy.deepcopy(dict(plantuml))
+        plantuml_config["generateDegradedDiagrams"] = False
+        writers["plantuml"] = plantuml_config
+    return writers
 
 
 def _optional_hint_str(value: object) -> str | None:

--- a/src/heimdall/manifests/services.py
+++ b/src/heimdall/manifests/services.py
@@ -7,18 +7,43 @@ from typing import TYPE_CHECKING
 from heimdall.manifests.pipeline import derive_lidskjalv_defaults
 from heimdall.models import (
     STEP_ANDVARI,
+    STEP_ANDVARI_V2,
+    STEP_ANDVARI_V3,
     STEP_BROKK,
     STEP_EITRI,
     STEP_EITRI_GENERATED,
+    STEP_EITRI_GENERATED_V2,
+    STEP_EITRI_GENERATED_V3,
     STEP_KVASIR,
+    STEP_KVASIR_V2,
+    STEP_KVASIR_V3,
     STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
     STEP_LIDSKJALV_ORIGINAL,
     STEP_MIMIR,
+    STEP_MIMIR_V2,
+    STEP_MIMIR_V3,
 )
 from heimdall.utils import read_json
 
 if TYPE_CHECKING:
     from heimdall.adapters import AdapterContext
+
+
+ANDVARI_STEPS = (STEP_ANDVARI, STEP_ANDVARI_V2, STEP_ANDVARI_V3)
+EITRI_GENERATED_STEPS = (
+    STEP_EITRI_GENERATED,
+    STEP_EITRI_GENERATED_V2,
+    STEP_EITRI_GENERATED_V3,
+)
+KVASIR_STEPS = (STEP_KVASIR, STEP_KVASIR_V2, STEP_KVASIR_V3)
+MIMIR_STEPS = (STEP_MIMIR, STEP_MIMIR_V2, STEP_MIMIR_V3)
+LIDSKJALV_GENERATED_STEPS = (
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
 
 
 def build_step_manifest_payload(
@@ -31,7 +56,7 @@ def build_step_manifest_payload(
             "repo_url": context.config.source.repo_url,
             "commit_sha": context.config.source.commit_sha,
         }
-    if step in {STEP_EITRI, STEP_EITRI_GENERATED}:
+    if step in {STEP_EITRI, *EITRI_GENERATED_STEPS}:
         payload: dict[str, object] = {
             "version": 1,
             "run_id": context.config.run_id,
@@ -46,7 +71,7 @@ def build_step_manifest_payload(
         if context.config.eitri.writers:
             payload["writers"] = context.config.eitri.writers
         return payload
-    if step == STEP_ANDVARI:
+    if step in ANDVARI_STEPS:
         return {
             "version": 1,
             "run_id": context.config.run_id,
@@ -57,7 +82,7 @@ def build_step_manifest_payload(
             "model_gate_timeout_sec": context.config.andvari.model_gate_timeout_sec,
             "diagram_relpath": "diagram.puml",
         }
-    if step == STEP_KVASIR:
+    if step in KVASIR_STEPS:
         payload = {
             "version": 1,
             "run_id": context.config.run_id,
@@ -74,57 +99,52 @@ def build_step_manifest_payload(
                 context.config.kvasir.write_scope_ignore_prefixes
             )
         return payload
-    if step == STEP_MIMIR:
-        snapshot_sources = mimir_snapshot_sources(context.run_root)
-        if "original" not in snapshot_sources:
-            return {
-                "version": 1,
-                "run_id": context.config.run_id,
-                "mode": "analytics",
-                "baseline_label": "original",
-                "baseline_snapshot_relpath": "original/model_snapshot.json",
-                "candidates": [
-                    {
-                        "label": "andvari_generated",
-                        "snapshot_relpath": "andvari_generated/model_snapshot.json",
-                    }
-                ],
-            }
+    if step in MIMIR_STEPS:
+        diagram_sources = mimir_diagram_sources(step, context.run_root)
+        candidate_label = _mimir_candidate_label(step)
         candidates = [
-            {"label": label, "snapshot_relpath": f"{label}/model_snapshot.json"}
-            for label in snapshot_sources
+            {"label": label, "diagram_relpath": f"{label}/diagram.puml"}
+            for label in diagram_sources
             if label != "original"
         ]
         if not candidates:
             candidates = [
                 {
-                    "label": "andvari_generated",
-                    "snapshot_relpath": "andvari_generated/model_snapshot.json",
+                    "label": candidate_label,
+                    "diagram_relpath": f"{candidate_label}/diagram.puml",
                 }
             ]
         return {
             "version": 1,
             "run_id": context.config.run_id,
-            "mode": "analytics",
+            "mode": "diagram",
             "baseline_label": "original",
-            "baseline_snapshot_relpath": "original/model_snapshot.json",
+            "baseline_diagram_relpath": "original/diagram.puml",
             "candidates": candidates,
         }
 
-    generated = step == STEP_LIDSKJALV_GENERATED
+    generated = step in LIDSKJALV_GENERATED_STEPS
     defaults = _derive_scan_defaults(context)
     target_config = (
         context.config.lidskjalv.generated
         if generated
         else context.config.lidskjalv.original
     )
-    scan_label = "generated" if generated else "original"
+    scan_label = _lidskjalv_scan_label(step) if generated else "original"
     payload = {
         "version": 1,
         "run_id": context.config.run_id,
         "scan_label": scan_label,
-        "project_key": target_config.project_key or defaults[f"{scan_label}_key"],
-        "project_name": target_config.project_name or defaults[f"{scan_label}_name"],
+        "project_key": _lidskjalv_project_key(
+            target_config.project_key, defaults["generated_key"], step
+        )
+        if generated
+        else target_config.project_key or defaults["original_key"],
+        "project_name": _lidskjalv_project_name(
+            target_config.project_name, defaults["generated_name"], step
+        )
+        if generated
+        else target_config.project_name or defaults["original_name"],
         "skip_sonar": context.config.lidskjalv.skip_sonar,
     }
     if target_config.repo_subdir is not None:
@@ -135,14 +155,16 @@ def build_step_manifest_payload(
 def build_step_runtime_hints(
     step: str, context: AdapterContext
 ) -> dict[str, object] | None:
-    if step != STEP_KVASIR:
+    if step not in KVASIR_STEPS:
         return None
 
     hints: dict[str, object] = {}
-    original = _lidskjalv_build_hint(context.run_root, generated=False)
+    original = _lidskjalv_build_hint(context.run_root, STEP_LIDSKJALV_ORIGINAL)
     if original:
         hints["original"] = original
-    generated = _lidskjalv_build_hint(context.run_root, generated=True)
+    generated = _lidskjalv_build_hint(
+        context.run_root, _lidskjalv_generated_step_for_kvasir_step(step)
+    )
     if generated:
         hints["generated"] = generated
     return hints or None
@@ -152,7 +174,7 @@ def brokk_source_manifest(run_root: Path) -> Path:
     return run_root / "services" / "brokk" / "run" / "inputs" / "source-manifest.json"
 
 
-def mimir_snapshot_sources(run_root: Path) -> dict[str, Path]:
+def mimir_diagram_sources(step: str, run_root: Path) -> dict[str, Path]:
     sources: dict[str, Path] = {}
     original = (
         run_root
@@ -161,38 +183,23 @@ def mimir_snapshot_sources(run_root: Path) -> dict[str, Path]:
         / "run"
         / "artifacts"
         / "model"
-        / "model_snapshot.json"
+        / "diagram.puml"
     )
     if original.is_file():
         sources["original"] = original
 
+    candidate_label = _mimir_candidate_label(step)
     generated = (
         run_root
         / "services"
-        / "eitri-generated"
+        / _eitri_generated_service_for_mimir_step(step)
         / "run"
         / "artifacts"
         / "model"
-        / "model_snapshot.json"
+        / "diagram.puml"
     )
     if generated.is_file():
-        sources["andvari_generated"] = generated
-
-    services_root = run_root / "services"
-    if services_root.is_dir():
-        for service_dir in sorted(services_root.iterdir()):
-            if not service_dir.is_dir():
-                continue
-            name = service_dir.name
-            if not name.startswith("eitri-") or name == "eitri-generated":
-                continue
-            snapshot = (
-                service_dir / "run" / "artifacts" / "model" / "model_snapshot.json"
-            )
-            if not snapshot.is_file():
-                continue
-            label = name.removeprefix("eitri-").replace("-", "_")
-            sources.setdefault(label, snapshot)
+        sources[candidate_label] = generated
     return dict(sorted(sources.items()))
 
 
@@ -205,11 +212,8 @@ def _derive_scan_defaults(context: AdapterContext) -> dict[str, str]:
     return derive_lidskjalv_defaults(repo_url)
 
 
-def _lidskjalv_build_hint(
-    run_root: Path, *, generated: bool
-) -> dict[str, object] | None:
-    step = STEP_LIDSKJALV_GENERATED if generated else STEP_LIDSKJALV_ORIGINAL
-    service_dir = "lidskjalv-generated" if generated else "lidskjalv-original"
+def _lidskjalv_build_hint(run_root: Path, step: str) -> dict[str, object] | None:
+    service_dir = _service_dir_for_step(step)
     report_path = (
         run_root / "services" / service_dir / "run" / "outputs" / "run_report.json"
     )
@@ -236,6 +240,63 @@ def _lidskjalv_build_hint(
 
     hint["source"] = step
     return hint
+
+
+def _branch_suffix(step: str) -> str:
+    if step.endswith("-v2"):
+        return "v2"
+    if step.endswith("-v3"):
+        return "v3"
+    return ""
+
+
+def _mimir_candidate_label(step: str) -> str:
+    suffix = _branch_suffix(step)
+    return "andvari_generated" if not suffix else f"andvari_generated_{suffix}"
+
+
+def _eitri_generated_service_for_mimir_step(step: str) -> str:
+    suffix = _branch_suffix(step)
+    return "eitri-generated" if not suffix else f"eitri-generated-{suffix}"
+
+
+def _lidskjalv_generated_step_for_kvasir_step(step: str) -> str:
+    suffix = _branch_suffix(step)
+    if suffix == "v2":
+        return STEP_LIDSKJALV_GENERATED_V2
+    if suffix == "v3":
+        return STEP_LIDSKJALV_GENERATED_V3
+    return STEP_LIDSKJALV_GENERATED
+
+
+def _lidskjalv_scan_label(step: str) -> str:
+    suffix = _branch_suffix(step)
+    return "generated" if not suffix else f"generated-{suffix}"
+
+
+def _lidskjalv_project_key(
+    configured: str | None, default: str, step: str
+) -> str:
+    suffix = _branch_suffix(step)
+    base = configured or default
+    return base if not suffix else f"{base}_{suffix}"
+
+
+def _lidskjalv_project_name(
+    configured: str | None, default: str, step: str
+) -> str:
+    suffix = _branch_suffix(step)
+    base = configured or default
+    return base if not suffix else f"{base} {suffix}"
+
+
+def _service_dir_for_step(step: str) -> str:
+    return {
+        STEP_LIDSKJALV_ORIGINAL: "lidskjalv-original",
+        STEP_LIDSKJALV_GENERATED: "lidskjalv-generated",
+        STEP_LIDSKJALV_GENERATED_V2: "lidskjalv-generated-v2",
+        STEP_LIDSKJALV_GENERATED_V3: "lidskjalv-generated-v3",
+    }[step]
 
 
 def _optional_hint_str(value: object) -> str | None:

--- a/src/heimdall/manifests/services.py
+++ b/src/heimdall/manifests/services.py
@@ -177,13 +177,7 @@ def brokk_source_manifest(run_root: Path) -> Path:
 def mimir_diagram_sources(step: str, run_root: Path) -> dict[str, Path]:
     sources: dict[str, Path] = {}
     original = (
-        run_root
-        / "services"
-        / "eitri"
-        / "run"
-        / "artifacts"
-        / "model"
-        / "diagram.puml"
+        run_root / "services" / "eitri" / "run" / "artifacts" / "model" / "diagram.puml"
     )
     if original.is_file():
         sources["original"] = original
@@ -274,17 +268,13 @@ def _lidskjalv_scan_label(step: str) -> str:
     return "generated" if not suffix else f"generated-{suffix}"
 
 
-def _lidskjalv_project_key(
-    configured: str | None, default: str, step: str
-) -> str:
+def _lidskjalv_project_key(configured: str | None, default: str, step: str) -> str:
     suffix = _branch_suffix(step)
     base = configured or default
     return base if not suffix else f"{base}_{suffix}"
 
 
-def _lidskjalv_project_name(
-    configured: str | None, default: str, step: str
-) -> str:
+def _lidskjalv_project_name(configured: str | None, default: str, step: str) -> str:
     suffix = _branch_suffix(step)
     base = configured or default
     return base if not suffix else f"{base} {suffix}"

--- a/src/heimdall/models.py
+++ b/src/heimdall/models.py
@@ -13,11 +13,21 @@ JobStatus = Literal["pending", "running", "passed", "failed", "error"]
 STEP_BROKK = "brokk"
 STEP_EITRI = "eitri"
 STEP_EITRI_GENERATED = "eitri-generated"
+STEP_EITRI_GENERATED_V2 = "eitri-generated-v2"
+STEP_EITRI_GENERATED_V3 = "eitri-generated-v3"
 STEP_ANDVARI = "andvari"
+STEP_ANDVARI_V2 = "andvari-v2"
+STEP_ANDVARI_V3 = "andvari-v3"
 STEP_MIMIR = "mimir"
+STEP_MIMIR_V2 = "mimir-v2"
+STEP_MIMIR_V3 = "mimir-v3"
 STEP_KVASIR = "kvasir"
+STEP_KVASIR_V2 = "kvasir-v2"
+STEP_KVASIR_V3 = "kvasir-v3"
 STEP_LIDSKJALV_ORIGINAL = "lidskjalv-original"
 STEP_LIDSKJALV_GENERATED = "lidskjalv-generated"
+STEP_LIDSKJALV_GENERATED_V2 = "lidskjalv-generated-v2"
+STEP_LIDSKJALV_GENERATED_V3 = "lidskjalv-generated-v3"
 
 ALL_STEPS = (
     STEP_BROKK,
@@ -28,6 +38,16 @@ ALL_STEPS = (
     STEP_MIMIR,
     STEP_KVASIR,
     STEP_LIDSKJALV_GENERATED,
+    STEP_ANDVARI_V2,
+    STEP_EITRI_GENERATED_V2,
+    STEP_MIMIR_V2,
+    STEP_KVASIR_V2,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_ANDVARI_V3,
+    STEP_EITRI_GENERATED_V3,
+    STEP_MIMIR_V3,
+    STEP_KVASIR_V3,
+    STEP_LIDSKJALV_GENERATED_V3,
 )
 
 
@@ -163,6 +183,7 @@ class StepDefinition:
     depends_on: tuple[str, ...]
     service_dir_name: str
     report_relative_path: str
+    order_after: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/src/heimdall/runner.py
+++ b/src/heimdall/runner.py
@@ -20,7 +20,11 @@ from heimdall.manifests.pipeline import pipeline_to_document, runtime_snapshot
 from heimdall.models import (
     STEP_EITRI,
     STEP_EITRI_GENERATED,
+    STEP_EITRI_GENERATED_V2,
+    STEP_EITRI_GENERATED_V3,
     STEP_MIMIR,
+    STEP_MIMIR_V2,
+    STEP_MIMIR_V3,
     PipelineConfig,
     ResolvedImages,
     RuntimeConfig,
@@ -116,8 +120,12 @@ def _collect_repository_stats(steps: dict[str, StepState]) -> dict[str, object]:
     aliases = (
         ("original", STEP_EITRI),
         ("andvari_generated", STEP_EITRI_GENERATED),
+        ("andvari_generated_v2", STEP_EITRI_GENERATED_V2),
+        ("andvari_generated_v3", STEP_EITRI_GENERATED_V3),
         ("lidskjalv_original_input", STEP_EITRI),
         ("lidskjalv_generated_input", STEP_EITRI_GENERATED),
+        ("lidskjalv_generated_v2_input", STEP_EITRI_GENERATED_V2),
+        ("lidskjalv_generated_v3_input", STEP_EITRI_GENERATED_V3),
     )
     repository_stats: dict[str, object] = {}
     for label, step in aliases:
@@ -146,18 +154,26 @@ def _collect_repository_stats(steps: dict[str, StepState]) -> dict[str, object]:
 
 
 def _collect_diagram_comparisons(steps: dict[str, StepState]) -> dict[str, object]:
-    state = steps.get(STEP_MIMIR)
-    if state is None or state.report_path is None or state.report_status != "passed":
-        return {}
-    report_path = Path(state.report_path)
-    if not report_path.is_file():
-        return {}
-    try:
-        report = json.loads(report_path.read_text(encoding="utf-8"))
-    except Exception:
-        return {}
-    comparisons = report.get("diagram_comparisons")
-    return dict(comparisons) if isinstance(comparisons, dict) else {}
+    merged: dict[str, object] = {}
+    for step in (STEP_MIMIR, STEP_MIMIR_V2, STEP_MIMIR_V3):
+        state = steps.get(step)
+        if (
+            state is None
+            or state.report_path is None
+            or state.report_status != "passed"
+        ):
+            continue
+        report_path = Path(state.report_path)
+        if not report_path.is_file():
+            continue
+        try:
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        comparisons = report.get("diagram_comparisons")
+        if isinstance(comparisons, dict):
+            merged.update(comparisons)
+    return merged
 
 
 def _run_scheduler(
@@ -179,6 +195,11 @@ def _run_scheduler(
                 definition = STEP_DEFINITIONS[step]
                 if any(
                     dependency not in finished for dependency in definition.depends_on
+                ):
+                    continue
+                if any(
+                    predecessor not in finished
+                    for predecessor in definition.order_after
                 ):
                     continue
                 blocked_by = [

--- a/src/heimdall/sonar_follow_up.py
+++ b/src/heimdall/sonar_follow_up.py
@@ -12,7 +12,13 @@ from pathlib import Path
 from typing import Any
 
 from heimdall.adapters import STEP_DEFINITIONS
-from heimdall.models import STEP_LIDSKJALV_GENERATED, STEP_LIDSKJALV_ORIGINAL, StepState
+from heimdall.models import (
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+    STEP_LIDSKJALV_ORIGINAL,
+    StepState,
+)
 from heimdall.reporting import load_report
 from heimdall.utils import timestamp_utc, write_text
 
@@ -23,7 +29,12 @@ SONAR_MEASURE_KEYS = (
     "reliability_rating,security_rating,sqale_rating,ncloc,sqale_index"
 )
 _FOLLOW_UP_TERMINAL_STATUSES = {"complete", "failed", "skipped"}
-_FOLLOW_UP_STEPS = (STEP_LIDSKJALV_ORIGINAL, STEP_LIDSKJALV_GENERATED)
+_FOLLOW_UP_STEPS = (
+    STEP_LIDSKJALV_ORIGINAL,
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
 
 
 def sonar_follow_up_path(run_root: Path) -> Path:
@@ -490,6 +501,10 @@ def _overall_status(entries: Any) -> str:
 def _scan_label_for_step(step: str) -> str:
     if step == STEP_LIDSKJALV_GENERATED:
         return "generated"
+    if step == STEP_LIDSKJALV_GENERATED_V2:
+        return "generated-v2"
+    if step == STEP_LIDSKJALV_GENERATED_V3:
+        return "generated-v3"
     return "original"
 
 

--- a/tests/fakes/docker
+++ b/tests/fakes/docker
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 import shutil
 import sys
+import time
 from typing import Any
 
 from heimdall.simpleyaml import loads
@@ -134,21 +135,22 @@ def _handle_run(args: list[str]) -> int:
 
     _mutate_state(update)
 
+    _maybe_sleep(step)
     if mode == "missing-report":
         return 0
     if step.startswith("smoke-"):
         return _run_provider_smoke(container, env_vars, mode)
     if step == "brokk":
         _run_brokk(container, manifest, mode)
-    elif step in {"eitri", "eitri-generated"}:
+    elif step == "eitri" or step.startswith("eitri-generated"):
         _run_eitri(container, manifest, mode)
-    elif step == "andvari":
+    elif step == "andvari" or step.startswith("andvari-"):
         _run_andvari(container, manifest, mode)
-    elif step == "mimir":
+    elif step == "mimir" or step.startswith("mimir-"):
         _run_mimir(container, manifest, mode)
-    elif step == "kvasir":
+    elif step == "kvasir" or step.startswith("kvasir-"):
         _run_kvasir(container, manifest, mode)
-    elif step in {"lidskjalv-original", "lidskjalv-generated"}:
+    elif step.startswith("lidskjalv-"):
         _run_lidskjalv(container, manifest, mode)
     else:
         print(f"unknown fake step for image {image_ref}", file=sys.stderr)
@@ -206,6 +208,9 @@ def _load_manifest(container: _ContainerMounts, env_vars: dict[str, str]) -> dic
 def _infer_step(
     image_ref: str, manifest: dict[str, Any], mounts: list[dict[str, Any]]
 ) -> str:
+    service_name = _service_name_from_mounts(mounts)
+    if service_name is not None:
+        return service_name
     lowered = image_ref.lower()
     if "brokk" in lowered:
         return "brokk"
@@ -223,6 +228,52 @@ def _infer_step(
         label = str(manifest.get("scan_label", "original"))
         return f"lidskjalv-{label}"
     return "unknown"
+
+
+def _service_name_from_mounts(mounts: list[dict[str, Any]]) -> str | None:
+    for mount in mounts:
+        if mount.get("container") not in {"/run", "/run/config"}:
+            continue
+        parts = Path(str(mount["host"])).parts
+        for index, part in enumerate(parts[:-1]):
+            if part != "services":
+                continue
+            service = parts[index + 1]
+            if service in {
+                "brokk",
+                "eitri",
+                "lidskjalv-original",
+                "andvari",
+                "andvari-v2",
+                "andvari-v3",
+                "eitri-generated",
+                "eitri-generated-v2",
+                "eitri-generated-v3",
+                "mimir",
+                "mimir-v2",
+                "mimir-v3",
+                "kvasir",
+                "kvasir-v2",
+                "kvasir-v3",
+                "lidskjalv-generated",
+                "lidskjalv-generated-v2",
+                "lidskjalv-generated-v3",
+            }:
+                return service
+    return None
+
+
+def _maybe_sleep(step: str) -> None:
+    env_name = f"FAKE_DOCKER_{step.upper().replace('-', '_')}_SLEEP_SEC"
+    raw = os.environ.get(env_name)
+    if raw is None:
+        return
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return
+    if seconds > 0:
+        time.sleep(seconds)
 
 
 def _run_provider_smoke(
@@ -312,6 +363,13 @@ def _run_eitri(container: _ContainerMounts, manifest: dict[str, Any], mode: str)
     snapshot_path = model_dir / "model_snapshot.json"
     repository_stats_path = model_dir / "repository_stats.json"
     diagram_path.write_text("@startuml\nclass Demo\n@enduml\n", encoding="utf-8")
+    if run_root.parent.name == "eitri":
+        (model_dir / "diagram_v2.puml").write_text(
+            "@startuml\nclass DemoV2\n@enduml\n", encoding="utf-8"
+        )
+        (model_dir / "diagram_v3.puml").write_text(
+            "@startuml\nclass DemoV3\n@enduml\n", encoding="utf-8"
+        )
     _write_json(
         snapshot_path,
         {

--- a/tests/fakes/docker
+++ b/tests/fakes/docker
@@ -344,7 +344,7 @@ def _run_eitri(container: _ContainerMounts, manifest: dict[str, Any], mode: str)
     snapshot_path = model_dir / "model_snapshot.json"
     repository_stats_path = model_dir / "repository_stats.json"
     diagram_path.write_text("@startuml\nclass Demo\n@enduml\n", encoding="utf-8")
-    if run_root.parent.name == "eitri":
+    if _should_generate_degraded_diagrams(manifest):
         (model_dir / "diagram_v2.puml").write_text(
             "@startuml\nclass DemoV2\n@enduml\n", encoding="utf-8"
         )
@@ -687,6 +687,17 @@ def _write_json(path: Path, payload: dict[str, Any]) -> None:
 def _write_summary(path: Path, title: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(f"# {title}\n", encoding="utf-8")
+
+
+def _should_generate_degraded_diagrams(manifest: dict[str, Any]) -> bool:
+    writers = manifest.get("writers")
+    if not isinstance(writers, dict):
+        return True
+    plantuml = writers.get("plantuml")
+    if not isinstance(plantuml, dict):
+        return True
+    raw = plantuml.get("generateDegradedDiagrams")
+    return raw is not False
 
 
 def _image_id(image_ref: str) -> str:

--- a/tests/fakes/docker
+++ b/tests/fakes/docker
@@ -239,26 +239,7 @@ def _service_name_from_mounts(mounts: list[dict[str, Any]]) -> str | None:
             if part != "services":
                 continue
             service = parts[index + 1]
-            if service in {
-                "brokk",
-                "eitri",
-                "lidskjalv-original",
-                "andvari",
-                "andvari-v2",
-                "andvari-v3",
-                "eitri-generated",
-                "eitri-generated-v2",
-                "eitri-generated-v3",
-                "mimir",
-                "mimir-v2",
-                "mimir-v3",
-                "kvasir",
-                "kvasir-v2",
-                "kvasir-v3",
-                "lidskjalv-generated",
-                "lidskjalv-generated-v2",
-                "lidskjalv-generated-v3",
-            }:
+            if service and service not in {".", ".."}:
                 return service
     return None
 

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -150,7 +150,9 @@ class AdapterTest(unittest.TestCase):
             )
             eitri_model.mkdir(parents=True, exist_ok=True)
             write_file(eitri_model / "diagram.puml", "@startuml\n@enduml\n")
-            write_file(eitri_model / "diagram_v2.puml", "@startuml\nclass V2\n@enduml\n")
+            write_file(
+                eitri_model / "diagram_v2.puml", "@startuml\nclass V2\n@enduml\n"
+            )
             andvari_generated = (
                 root
                 / "run-root"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -98,6 +98,10 @@ class AdapterTest(unittest.TestCase):
             eitri_manifest["writers"]["plantuml"]["diagramName"], "diagram"
         )
         self.assertEqual(eitri_manifest["writers"]["plantuml"]["hidePrivate"], True)
+        self.assertNotIn(
+            "generateDegradedDiagrams",
+            eitri_manifest["writers"]["plantuml"],
+        )
         self.assertEqual(
             [
                 (str(mount.host_path), mount.container_path, mount.read_only)
@@ -226,6 +230,8 @@ class AdapterTest(unittest.TestCase):
             kvasir_v2 = prepare_step("kvasir-v2", context)
             generated_eitri = prepare_step("eitri-generated", context)
             generated_eitri_v2 = prepare_step("eitri-generated-v2", context)
+            generated_eitri_manifest = loads(generated_eitri.manifest_text)
+            generated_eitri_v2_manifest = loads(generated_eitri_v2.manifest_text)
             hints = json.loads(
                 (kvasir.config_dir / "build-hints.json").read_text(encoding="utf-8")
             )
@@ -277,6 +283,21 @@ class AdapterTest(unittest.TestCase):
                 "/input/repo",
                 True,
             ),
+        )
+        self.assertEqual(
+            generated_eitri_manifest["writers"]["plantuml"]["diagramName"], "diagram"
+        )
+        self.assertEqual(
+            generated_eitri_manifest["writers"]["plantuml"][
+                "generateDegradedDiagrams"
+            ],
+            False,
+        )
+        self.assertEqual(
+            generated_eitri_v2_manifest["writers"]["plantuml"][
+                "generateDegradedDiagrams"
+            ],
+            False,
         )
 
     def test_prepare_generated_lidskjalv_mounts_kvasir_ported_repo(self) -> None:

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -288,9 +288,7 @@ class AdapterTest(unittest.TestCase):
             generated_eitri_manifest["writers"]["plantuml"]["diagramName"], "diagram"
         )
         self.assertEqual(
-            generated_eitri_manifest["writers"]["plantuml"][
-                "generateDegradedDiagrams"
-            ],
+            generated_eitri_manifest["writers"]["plantuml"]["generateDegradedDiagrams"],
             False,
         )
         self.assertEqual(

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -20,6 +20,16 @@ from tests.helpers import build_pipeline_manifest, write_file
 class AdapterTest(unittest.TestCase):
     def test_andvari_depends_only_on_eitri(self) -> None:
         self.assertEqual(step_definitions()["andvari"].depends_on, ("eitri",))
+        self.assertEqual(step_definitions()["andvari-v2"].depends_on, ("eitri",))
+        self.assertEqual(step_definitions()["andvari-v3"].depends_on, ("eitri",))
+        self.assertEqual(
+            step_definitions()["andvari-v2"].order_after,
+            ("mimir", "lidskjalv-generated"),
+        )
+        self.assertEqual(
+            step_definitions()["andvari-v3"].order_after,
+            ("mimir-v2", "lidskjalv-generated-v2"),
+        )
 
     def test_generated_eitri_depends_on_andvari(self) -> None:
         self.assertEqual(step_definitions()["eitri-generated"].depends_on, ("andvari",))
@@ -27,6 +37,12 @@ class AdapterTest(unittest.TestCase):
     def test_generated_lidskjalv_depends_on_kvasir(self) -> None:
         self.assertEqual(
             step_definitions()["lidskjalv-generated"].depends_on, ("kvasir",)
+        )
+        self.assertEqual(
+            step_definitions()["lidskjalv-generated-v2"].depends_on, ("kvasir-v2",)
+        )
+        self.assertEqual(
+            step_definitions()["lidskjalv-generated-v3"].depends_on, ("kvasir-v3",)
         )
 
     def test_prepare_eitri_and_lidskjalv_manifests(self) -> None:
@@ -134,6 +150,7 @@ class AdapterTest(unittest.TestCase):
             )
             eitri_model.mkdir(parents=True, exist_ok=True)
             write_file(eitri_model / "diagram.puml", "@startuml\n@enduml\n")
+            write_file(eitri_model / "diagram_v2.puml", "@startuml\nclass V2\n@enduml\n")
             andvari_generated = (
                 root
                 / "run-root"
@@ -145,6 +162,17 @@ class AdapterTest(unittest.TestCase):
             )
             andvari_generated.mkdir(parents=True, exist_ok=True)
             write_file(andvari_generated / "README.md", "generated\n")
+            andvari_v2_generated = (
+                root
+                / "run-root"
+                / "services"
+                / "andvari-v2"
+                / "run"
+                / "artifacts"
+                / "generated-repo"
+            )
+            andvari_v2_generated.mkdir(parents=True, exist_ok=True)
+            write_file(andvari_v2_generated / "README.md", "generated v2\n")
             write_file(
                 root
                 / "run-root"
@@ -193,10 +221,15 @@ class AdapterTest(unittest.TestCase):
             )
 
             kvasir = prepare_step("kvasir", context)
+            kvasir_v2 = prepare_step("kvasir-v2", context)
             generated_eitri = prepare_step("eitri-generated", context)
+            generated_eitri_v2 = prepare_step("eitri-generated-v2", context)
             hints = json.loads(
                 (kvasir.config_dir / "build-hints.json").read_text(encoding="utf-8")
             )
+            kvasir_v2_staged_diagram = (
+                kvasir_v2.service_root / "input" / "model" / "diagram.puml"
+            ).read_text(encoding="utf-8")
 
         self.assertEqual(
             kvasir.env["KVASIR_BUILD_HINTS"], "/run/config/build-hints.json"
@@ -213,6 +246,32 @@ class AdapterTest(unittest.TestCase):
             ][0],
             (
                 str(andvari_generated),
+                "/input/repo",
+                True,
+            ),
+        )
+        self.assertEqual(
+            [
+                (str(mount.host_path), mount.container_path, mount.read_only)
+                for mount in kvasir_v2.mounts
+            ][1],
+            (
+                str(andvari_v2_generated),
+                "/input/generated-repo",
+                True,
+            ),
+        )
+        self.assertEqual(
+            kvasir_v2_staged_diagram,
+            "@startuml\nclass V2\n@enduml\n",
+        )
+        self.assertEqual(
+            [
+                (str(mount.host_path), mount.container_path, mount.read_only)
+                for mount in generated_eitri_v2.mounts
+            ][0],
+            (
+                str(andvari_v2_generated),
                 "/input/repo",
                 True,
             ),
@@ -239,6 +298,17 @@ class AdapterTest(unittest.TestCase):
             )
             ported_repo.mkdir(parents=True, exist_ok=True)
             write_file(ported_repo / "README.md", "ported\n")
+            ported_repo_v2 = (
+                root
+                / "run-root"
+                / "services"
+                / "kvasir-v2"
+                / "run"
+                / "artifacts"
+                / "ported-tests-repo"
+            )
+            ported_repo_v2.mkdir(parents=True, exist_ok=True)
+            write_file(ported_repo_v2 / "README.md", "ported v2\n")
             runtime = RuntimeConfig(
                 runs_root=root / "runs",
                 codex_bin_dir=root / "provider" / "bin",
@@ -266,6 +336,7 @@ class AdapterTest(unittest.TestCase):
             )
 
             generated = prepare_step("lidskjalv-generated", context)
+            generated_v2 = prepare_step("lidskjalv-generated-v2", context)
 
         self.assertEqual(
             [
@@ -287,6 +358,13 @@ class AdapterTest(unittest.TestCase):
                     False,
                 ),
             ],
+        )
+        self.assertEqual(
+            [
+                (str(mount.host_path), mount.container_path, mount.read_only)
+                for mount in generated_v2.mounts
+            ][0],
+            (str(ported_repo_v2), "/input/repo", True),
         )
 
     def test_classify_kvasir_records_promoted_ported_repo(self) -> None:
@@ -321,7 +399,7 @@ class AdapterTest(unittest.TestCase):
             manifest_path = root / "pipeline.yaml"
             write_file(manifest_path, build_pipeline_manifest())
             _raw, config = load_pipeline_manifest(manifest_path)
-            original_snapshot = (
+            original_diagram = (
                 root
                 / "run-root"
                 / "services"
@@ -329,9 +407,9 @@ class AdapterTest(unittest.TestCase):
                 / "run"
                 / "artifacts"
                 / "model"
-                / "model_snapshot.json"
+                / "diagram.puml"
             )
-            generated_snapshot = (
+            generated_diagram = (
                 root
                 / "run-root"
                 / "services"
@@ -339,14 +417,10 @@ class AdapterTest(unittest.TestCase):
                 / "run"
                 / "artifacts"
                 / "model"
-                / "model_snapshot.json"
+                / "diagram.puml"
             )
-            write_file(
-                original_snapshot, '{"schema_version":"uml_model_snapshot.v1"}\n'
-            )
-            write_file(
-                generated_snapshot, '{"schema_version":"uml_model_snapshot.v1"}\n'
-            )
+            write_file(original_diagram, "@startuml\nclass Original\n@enduml\n")
+            write_file(generated_diagram, "@startuml\nclass Generated\n@enduml\n")
             runtime = RuntimeConfig(
                 runs_root=root / "runs",
                 codex_bin_dir=root / "provider" / "bin",
@@ -374,16 +448,28 @@ class AdapterTest(unittest.TestCase):
             )
 
             mimir = prepare_step("mimir", context)
+            staged_generated_diagram = (
+                mimir.run_dir
+                / "inputs"
+                / "diagrams"
+                / "andvari_generated"
+                / "diagram.puml"
+            ).read_text(encoding="utf-8")
 
         mimir_manifest = loads(mimir.manifest_text)
+        self.assertEqual(mimir_manifest["mode"], "diagram")
         self.assertEqual(mimir_manifest["baseline_label"], "original")
         self.assertEqual(
-            mimir_manifest["baseline_snapshot_relpath"], "original/model_snapshot.json"
+            mimir_manifest["baseline_diagram_relpath"], "original/diagram.puml"
         )
         self.assertEqual(mimir_manifest["candidates"][0]["label"], "andvari_generated")
         self.assertEqual(
-            mimir_manifest["candidates"][0]["snapshot_relpath"],
-            "andvari_generated/model_snapshot.json",
+            mimir_manifest["candidates"][0]["diagram_relpath"],
+            "andvari_generated/diagram.puml",
+        )
+        self.assertEqual(
+            staged_generated_diagram,
+            "@startuml\nclass Generated\n@enduml\n",
         )
         self.assertEqual(mimir.env["MIMIR_MANIFEST"], "/run/config/manifest.yaml")
         self.assertEqual(

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -353,9 +353,6 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         self.assertLess(
             run_by_step["kvasir"]["seq"], run_by_step["lidskjalv-generated"]["seq"]
         )
-        self.assertLess(
-            run_by_step["mimir"]["seq"], run_by_step["lidskjalv-generated"]["seq"]
-        )
         self.assertLess(run_by_step["mimir"]["seq"], run_by_step["andvari-v2"]["seq"])
         self.assertLess(
             run_by_step["lidskjalv-generated"]["seq"],

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -41,7 +41,8 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
                 str(self.bin_dir),
                 "--codex-home-dir",
                 str(self.home_dir),
-            ]
+            ],
+            extra_env={"FAKE_DOCKER_KVASIR_SLEEP_SEC": "0.2"},
         )
         self.assertEqual(completed.returncode, 0, completed.stderr)
 
@@ -66,27 +67,41 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         )
 
         self.assertEqual(pipeline_report["status"], "passed")
-        self.assertEqual(pipeline_report["steps"]["brokk"]["status"], "passed")
-        self.assertEqual(pipeline_report["steps"]["eitri"]["status"], "passed")
-        self.assertEqual(pipeline_report["steps"]["andvari"]["status"], "passed")
-        self.assertEqual(
-            pipeline_report["steps"]["eitri-generated"]["status"], "passed"
-        )
-        self.assertEqual(pipeline_report["steps"]["mimir"]["status"], "passed")
-        self.assertEqual(pipeline_report["steps"]["kvasir"]["status"], "passed")
-        self.assertEqual(
-            pipeline_report["steps"]["lidskjalv-original"]["status"], "passed"
-        )
-        self.assertEqual(
-            pipeline_report["steps"]["lidskjalv-generated"]["status"], "passed"
-        )
+        expected_steps = {
+            "brokk",
+            "eitri",
+            "lidskjalv-original",
+            "andvari",
+            "eitri-generated",
+            "mimir",
+            "kvasir",
+            "lidskjalv-generated",
+            "andvari-v2",
+            "eitri-generated-v2",
+            "mimir-v2",
+            "kvasir-v2",
+            "lidskjalv-generated-v2",
+            "andvari-v3",
+            "eitri-generated-v3",
+            "mimir-v3",
+            "kvasir-v3",
+            "lidskjalv-generated-v3",
+        }
+        self.assertEqual(set(pipeline_report["steps"]), expected_steps)
+        for step in expected_steps:
+            self.assertEqual(pipeline_report["steps"][step]["status"], "passed")
         self.assertEqual(sonar_follow_up["status"], "skipped")
         self.assertEqual(
-            sonar_follow_up["steps"]["lidskjalv-original"]["status"], "skipped"
+            set(sonar_follow_up["steps"]),
+            {
+                "lidskjalv-original",
+                "lidskjalv-generated",
+                "lidskjalv-generated-v2",
+                "lidskjalv-generated-v3",
+            },
         )
-        self.assertEqual(
-            sonar_follow_up["steps"]["lidskjalv-generated"]["status"], "skipped"
-        )
+        for step in sonar_follow_up["steps"]:
+            self.assertEqual(sonar_follow_up["steps"][step]["status"], "skipped")
         self.assertEqual(eitri_report["status"], "passed")
         self.assertEqual(
             eitri_report["artifacts"]["diagram_path"],
@@ -105,7 +120,31 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
             "eitri-generated",
         )
         self.assertEqual(
+            pipeline_report["repository_stats"]["andvari_generated_v2"][
+                "source_step"
+            ],
+            "eitri-generated-v2",
+        )
+        self.assertEqual(
+            pipeline_report["repository_stats"]["andvari_generated_v3"][
+                "source_step"
+            ],
+            "eitri-generated-v3",
+        )
+        self.assertEqual(
             pipeline_report["diagram_comparisons"]["andvari_generated"][
+                "exact_similarity"
+            ],
+            1.0,
+        )
+        self.assertEqual(
+            pipeline_report["diagram_comparisons"]["andvari_generated_v2"][
+                "exact_similarity"
+            ],
+            1.0,
+        )
+        self.assertEqual(
+            pipeline_report["diagram_comparisons"]["andvari_generated_v3"][
                 "exact_similarity"
             ],
             1.0,
@@ -126,7 +165,40 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
             (
                 run_root
                 / "services"
+                / "eitri"
+                / "run"
+                / "artifacts"
+                / "model"
+                / "diagram_v2.puml"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                run_root
+                / "services"
+                / "eitri"
+                / "run"
+                / "artifacts"
+                / "model"
+                / "diagram_v3.puml"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                run_root
+                / "services"
                 / "eitri-generated"
+                / "run"
+                / "artifacts"
+                / "model"
+                / "model_snapshot.json"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                run_root
+                / "services"
+                / "eitri-generated-v2"
                 / "run"
                 / "artifacts"
                 / "model"
@@ -142,6 +214,17 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
                 / "artifacts"
                 / "comparisons"
                 / "andvari_generated.json"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
+                run_root
+                / "services"
+                / "mimir-v2"
+                / "run"
+                / "artifacts"
+                / "comparisons"
+                / "andvari_generated_v2.json"
             ).is_file()
         )
         self.assertTrue(
@@ -168,6 +251,17 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         )
         self.assertTrue(
             (
+                run_root
+                / "services"
+                / "andvari-v3"
+                / "run"
+                / "artifacts"
+                / "generated-repo"
+                / "README.md"
+            ).is_file()
+        )
+        self.assertTrue(
+            (
                 run_root / "services" / "kvasir" / "run" / "outputs" / "test_port.json"
             ).is_file()
         )
@@ -182,28 +276,65 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
                 / "README.md"
             ).is_file()
         )
+        self.assertTrue(
+            (
+                run_root
+                / "services"
+                / "kvasir-v2"
+                / "run"
+                / "artifacts"
+                / "ported-tests-repo"
+                / "README.md"
+            ).is_file()
+        )
         self.assertEqual(
             set(artifact_index["artifacts"]),
             {
                 "andvari_logs",
+                "andvari_logs_v2",
+                "andvari_logs_v3",
                 "andvari_report_dir",
+                "andvari_report_dir_v2",
+                "andvari_report_dir_v3",
                 "generated_repo",
+                "generated_repo_v2",
+                "generated_repo_v3",
                 "generated_model_diagram",
+                "generated_model_diagram_v2",
+                "generated_model_diagram_v3",
                 "generated_model_logs",
+                "generated_model_logs_v2",
+                "generated_model_logs_v3",
                 "generated_model_repository_stats",
+                "generated_model_repository_stats_v2",
+                "generated_model_repository_stats_v3",
                 "generated_model_snapshot",
+                "generated_model_snapshot_v2",
+                "generated_model_snapshot_v3",
                 "diagram_comparison_aggregate",
+                "diagram_comparison_aggregate_v2",
+                "diagram_comparison_aggregate_v3",
                 "diagram_comparison_andvari_generated",
+                "diagram_comparison_andvari_generated_v2",
+                "diagram_comparison_andvari_generated_v3",
                 "kvasir_report",
+                "kvasir_v2_report",
+                "kvasir_v3_report",
                 "lidskjalv_generated_report",
+                "lidskjalv_generated_v2_report",
+                "lidskjalv_generated_v3_report",
                 "lidskjalv_original_report",
                 "model_diagram",
                 "model_logs",
                 "model_repository_stats",
                 "model_snapshot",
                 "mimir_report",
+                "mimir_v2_report",
+                "mimir_v3_report",
                 "original_repo",
                 "ported_tests_repo",
+                "ported_tests_repo_v2",
+                "ported_tests_repo_v3",
                 "source_manifest",
             },
         )
@@ -226,9 +357,30 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         self.assertLess(
             run_by_step["kvasir"]["seq"], run_by_step["lidskjalv-generated"]["seq"]
         )
+        self.assertLess(
+            run_by_step["mimir"]["seq"], run_by_step["lidskjalv-generated"]["seq"]
+        )
+        self.assertLess(
+            run_by_step["mimir"]["seq"], run_by_step["andvari-v2"]["seq"]
+        )
+        self.assertLess(
+            run_by_step["lidskjalv-generated"]["seq"],
+            run_by_step["andvari-v2"]["seq"],
+        )
+        self.assertLess(
+            run_by_step["mimir-v2"]["seq"], run_by_step["andvari-v3"]["seq"]
+        )
+        self.assertLess(
+            run_by_step["lidskjalv-generated-v2"]["seq"],
+            run_by_step["andvari-v3"]["seq"],
+        )
         lidskjalv_generated_mounts = {
             mount["container"]: Path(mount["host"])
             for mount in run_by_step["lidskjalv-generated"]["mounts"]
+        }
+        lidskjalv_generated_v2_mounts = {
+            mount["container"]: Path(mount["host"])
+            for mount in run_by_step["lidskjalv-generated-v2"]["mounts"]
         }
         self.assertEqual(
             lidskjalv_generated_mounts["/input/repo"].resolve(),
@@ -236,6 +388,17 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
                 run_root
                 / "services"
                 / "kvasir"
+                / "run"
+                / "artifacts"
+                / "ported-tests-repo"
+            ).resolve(),
+        )
+        self.assertEqual(
+            lidskjalv_generated_v2_mounts["/input/repo"].resolve(),
+            (
+                run_root
+                / "services"
+                / "kvasir-v2"
                 / "run"
                 / "artifacts"
                 / "ported-tests-repo"

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -400,6 +400,8 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
             self.assertNotIn(run_root / "pipeline" / "manifest.yaml", mount_hosts)
 
         eitri_manifest = run_by_step["eitri"]["manifest"]
+        generated_eitri_manifest = run_by_step["eitri-generated"]["manifest"]
+        generated_eitri_v2_manifest = run_by_step["eitri-generated-v2"]["manifest"]
         self.assertEqual(eitri_manifest["writer_extension"], ".puml")
         self.assertEqual(
             eitri_manifest["writers"]["plantuml"]["diagramName"], "diagram"
@@ -407,6 +409,22 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         self.assertEqual(
             eitri_manifest["writers"]["plantuml"]["hidePrivate"],
             True,
+        )
+        self.assertNotIn(
+            "generateDegradedDiagrams",
+            eitri_manifest["writers"]["plantuml"],
+        )
+        self.assertEqual(
+            generated_eitri_manifest["writers"]["plantuml"][
+                "generateDegradedDiagrams"
+            ],
+            False,
+        )
+        self.assertEqual(
+            generated_eitri_v2_manifest["writers"]["plantuml"][
+                "generateDegradedDiagrams"
+            ],
+            False,
         )
 
     def _run_cli(

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -120,15 +120,11 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
             "eitri-generated",
         )
         self.assertEqual(
-            pipeline_report["repository_stats"]["andvari_generated_v2"][
-                "source_step"
-            ],
+            pipeline_report["repository_stats"]["andvari_generated_v2"]["source_step"],
             "eitri-generated-v2",
         )
         self.assertEqual(
-            pipeline_report["repository_stats"]["andvari_generated_v3"][
-                "source_step"
-            ],
+            pipeline_report["repository_stats"]["andvari_generated_v3"]["source_step"],
             "eitri-generated-v3",
         )
         self.assertEqual(
@@ -360,9 +356,7 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
         self.assertLess(
             run_by_step["mimir"]["seq"], run_by_step["lidskjalv-generated"]["seq"]
         )
-        self.assertLess(
-            run_by_step["mimir"]["seq"], run_by_step["andvari-v2"]["seq"]
-        )
+        self.assertLess(run_by_step["mimir"]["seq"], run_by_step["andvari-v2"]["seq"])
         self.assertLess(
             run_by_step["lidskjalv-generated"]["seq"],
             run_by_step["andvari-v2"]["seq"],

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -415,9 +415,7 @@ class PipelineSmokeIntegrationTest(unittest.TestCase):
             eitri_manifest["writers"]["plantuml"],
         )
         self.assertEqual(
-            generated_eitri_manifest["writers"]["plantuml"][
-                "generateDegradedDiagrams"
-            ],
+            generated_eitri_manifest["writers"]["plantuml"]["generateDegradedDiagrams"],
             False,
         )
         self.assertEqual(

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -319,6 +319,18 @@ class QueueIntegrationTest(unittest.TestCase):
             ],
             "pending",
         )
+        self.assertEqual(
+            finished_document["sonar_follow_up"]["steps"]["lidskjalv-generated-v2"][
+                "status"
+            ],
+            "pending",
+        )
+        self.assertEqual(
+            finished_document["sonar_follow_up"]["steps"]["lidskjalv-generated-v3"][
+                "status"
+            ],
+            "pending",
+        )
 
     def test_submit_shells_out_over_ssh(self) -> None:
         overrides_path = self.root / "overrides.yaml"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -179,16 +179,12 @@ class RunnerIntegrationTest(unittest.TestCase):
         self.assertEqual(report["steps"]["eitri-generated-v2"]["status"], "blocked")
         self.assertEqual(report["steps"]["mimir-v2"]["status"], "blocked")
         self.assertEqual(report["steps"]["kvasir-v2"]["status"], "blocked")
-        self.assertEqual(
-            report["steps"]["lidskjalv-generated-v2"]["status"], "blocked"
-        )
+        self.assertEqual(report["steps"]["lidskjalv-generated-v2"]["status"], "blocked")
         self.assertEqual(report["steps"]["andvari-v3"]["status"], "blocked")
         self.assertEqual(report["steps"]["eitri-generated-v3"]["status"], "blocked")
         self.assertEqual(report["steps"]["mimir-v3"]["status"], "blocked")
         self.assertEqual(report["steps"]["kvasir-v3"]["status"], "blocked")
-        self.assertEqual(
-            report["steps"]["lidskjalv-generated-v3"]["status"], "blocked"
-        )
+        self.assertEqual(report["steps"]["lidskjalv-generated-v3"]["status"], "blocked")
 
     def test_codex_home_is_staged_into_readable_provider_seed_mounts(self) -> None:
         write_file(self.home_dir / "auth.json", '{"token":"demo"}\n', mode=0o600)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -55,6 +55,16 @@ class RunnerIntegrationTest(unittest.TestCase):
             )
         )
         self.assertEqual(failed_report["steps"]["kvasir"]["status"], "failed")
+        self.assertEqual(
+            failed_report["steps"]["lidskjalv-generated"]["status"], "blocked"
+        )
+        self.assertEqual(failed_report["steps"]["andvari-v2"]["status"], "passed")
+        self.assertEqual(failed_report["steps"]["mimir-v2"]["status"], "passed")
+        self.assertEqual(
+            failed_report["steps"]["lidskjalv-generated-v2"]["status"], "passed"
+        )
+        self.assertEqual(failed_report["steps"]["andvari-v3"]["status"], "passed")
+        self.assertEqual(failed_report["steps"]["mimir-v3"]["status"], "passed")
 
         resumed = self._run_cli(
             [
@@ -114,11 +124,26 @@ class RunnerIntegrationTest(unittest.TestCase):
         self.assertEqual(resumed.returncode, 0, resumed.stderr)
 
         runs = load_fake_state(self.state_path)["runs"]
-        rerun_steps = [entry["step"] for entry in runs[-5:]]
-        self.assertEqual(rerun_steps[0], "andvari")
+        rerun_steps = [entry["step"] for entry in runs[-15:]]
         self.assertEqual(
-            set(rerun_steps[1:]),
-            {"eitri-generated", "mimir", "kvasir", "lidskjalv-generated"},
+            set(rerun_steps),
+            {
+                "andvari",
+                "eitri-generated",
+                "mimir",
+                "kvasir",
+                "lidskjalv-generated",
+                "andvari-v2",
+                "eitri-generated-v2",
+                "mimir-v2",
+                "kvasir-v2",
+                "lidskjalv-generated-v2",
+                "andvari-v3",
+                "eitri-generated-v3",
+                "mimir-v3",
+                "kvasir-v3",
+                "lidskjalv-generated-v3",
+            },
         )
 
     def test_missing_report_marks_step_error_and_blocks_downstream(self) -> None:
@@ -150,6 +175,20 @@ class RunnerIntegrationTest(unittest.TestCase):
         self.assertEqual(report["steps"]["mimir"]["status"], "blocked")
         self.assertEqual(report["steps"]["kvasir"]["status"], "blocked")
         self.assertEqual(report["steps"]["lidskjalv-generated"]["status"], "blocked")
+        self.assertEqual(report["steps"]["andvari-v2"]["status"], "blocked")
+        self.assertEqual(report["steps"]["eitri-generated-v2"]["status"], "blocked")
+        self.assertEqual(report["steps"]["mimir-v2"]["status"], "blocked")
+        self.assertEqual(report["steps"]["kvasir-v2"]["status"], "blocked")
+        self.assertEqual(
+            report["steps"]["lidskjalv-generated-v2"]["status"], "blocked"
+        )
+        self.assertEqual(report["steps"]["andvari-v3"]["status"], "blocked")
+        self.assertEqual(report["steps"]["eitri-generated-v3"]["status"], "blocked")
+        self.assertEqual(report["steps"]["mimir-v3"]["status"], "blocked")
+        self.assertEqual(report["steps"]["kvasir-v3"]["status"], "blocked")
+        self.assertEqual(
+            report["steps"]["lidskjalv-generated-v3"]["status"], "blocked"
+        )
 
     def test_codex_home_is_staged_into_readable_provider_seed_mounts(self) -> None:
         write_file(self.home_dir / "auth.json", '{"token":"demo"}\n', mode=0o600)


### PR DESCRIPTION
- Add best-effort, v2, and v3 generated branches with suffixed service steps, artifacts, manifests, and reporting.

- Introduce scheduler-only soft order barriers so v2 waits for the best-effort branch to finish and v3 waits for v2, without blocking on prior branch failure. Stage branch-specific diagrams into Andvari/Kvasir, compare generated diagrams with Mimir per branch, and wire generated Lidskjalv scans to matching Kvasir ported-test repos.

- Extend Sonar follow-up, fake Docker support, and integration coverage for the new multi-branch flow.