### PR TITLE
feat: add Heimdall analysis export tooling

### DIFF
--- a/scripts/backfill_sonar_project_metrics.py
+++ b/scripts/backfill_sonar_project_metrics.py
@@ -1,0 +1,408 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+from heimdall.sonar_follow_up import (  # noqa: E402
+    SONAR_MEASURE_KEYS,
+    _extract_measures,
+    _sonar_api_get_json,
+)
+from heimdall.utils import timestamp_utc  # noqa: E402
+
+import export_analysis_bundle as export_bundle  # noqa: E402
+import resubmit_missing_sonar as batch_scope  # noqa: E402
+
+
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+DEFAULT_SONAR_SIDECAR_ROOT = Path("/srv/pipeline/retries/sonar-resubmission")
+AUDIT_FILENAME = "project_metrics_backfill.json"
+AUDIT_CSV_FILENAME = "project_metrics_backfill.csv"
+
+
+@dataclass(frozen=True)
+class ExpectedProject:
+    agent: str
+    run_id: str
+    variant: str
+    step: str
+    project_key: str
+
+
+@dataclass(frozen=True)
+class FollowUpDestination:
+    path: Path
+    source: str
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill Sonar metrics by project key for the current Codex/Claude "
+            "experiment batch. This is for cases where Sonar projects exist but "
+            "run logs still have missing, pending, failed, or partial metrics."
+        )
+    )
+    parser.add_argument("--runs-root", type=Path, default=DEFAULT_RUNS_ROOT)
+    parser.add_argument(
+        "--sonar-sidecar-root", type=Path, default=DEFAULT_SONAR_SIDECAR_ROOT
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Write refreshed metrics into matching sonar_follow_up.json files.",
+    )
+    parser.add_argument(
+        "--require-all-metrics",
+        action="store_true",
+        help=(
+            "Treat a Sonar project as incomplete unless all configured metrics are "
+            "returned. Without this, any returned measure set is accepted."
+        ),
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    sonar_host_url = os.environ.get("SONAR_HOST_URL")
+    sonar_token = os.environ.get("SONAR_TOKEN")
+    missing = [
+        name
+        for name, value in {
+            "SONAR_HOST_URL": sonar_host_url,
+            "SONAR_TOKEN": sonar_token,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Missing required Sonar environment variable(s): {', '.join(missing)}"
+        )
+    assert sonar_host_url is not None
+    assert sonar_token is not None
+
+    result = backfill_project_metrics(
+        runs_root=args.runs_root,
+        sonar_sidecar_root=args.sonar_sidecar_root,
+        sonar_host_url=sonar_host_url,
+        sonar_token=sonar_token,
+        apply=args.apply,
+        require_all_metrics=args.require_all_metrics,
+    )
+    print(
+        f"expected_rows={result['expected_rows']} "
+        f"expected_projects={result['expected_projects']} "
+        f"queried={result['queried']} "
+        f"available={result['available']} "
+        f"missing_or_inaccessible={result['missing_or_inaccessible']} "
+        f"updated_entries={result['updated_entries']} "
+        f"apply={args.apply}"
+    )
+    print(f"audit={result['audit_path']}")
+    print(f"audit_csv={result['audit_csv_path']}")
+    return 0 if result["missing_or_inaccessible"] == 0 else 1
+
+
+def backfill_project_metrics(
+    *,
+    runs_root: Path,
+    sonar_sidecar_root: Path,
+    sonar_host_url: str,
+    sonar_token: str,
+    apply: bool,
+    require_all_metrics: bool = False,
+) -> dict[str, object]:
+    expected = discover_expected_projects(runs_root)
+    unique_keys = sorted({item.project_key for item in expected})
+    destinations = discover_follow_up_destinations(runs_root, sonar_sidecar_root)
+    destinations_by_project = index_destinations_by_project(destinations)
+
+    rows: list[dict[str, object]] = []
+    fetched: dict[str, dict[str, object]] = {}
+    for project_key in unique_keys:
+        project = fetch_project_metrics(
+            project_key,
+            sonar_host_url=sonar_host_url,
+            sonar_token=sonar_token,
+            require_all_metrics=require_all_metrics,
+        )
+        fetched[project_key] = project
+        rows.append(
+            {
+                "project_key": project_key,
+                "status": project["status"],
+                "quality_gate_status": project.get("quality_gate_status"),
+                "metric_count": len(mapping(project.get("measures"))),
+                "missing_metrics": ",".join(project.get("missing_metrics", [])),
+                "error": project.get("error"),
+                "destination_count": len(destinations_by_project.get(project_key, [])),
+            }
+        )
+
+    updated_entries = 0
+    if apply:
+        updated_entries = apply_metric_updates(destinations, fetched)
+
+    audit_path = sonar_sidecar_root / AUDIT_FILENAME
+    audit_csv_path = sonar_sidecar_root / AUDIT_CSV_FILENAME
+    write_json(
+        audit_path,
+        {
+            "schema_version": "heimdall_sonar_project_metrics_backfill.v1",
+            "generated_at": timestamp_utc(),
+            "applied": apply,
+            "expected_rows": len(expected),
+            "expected_projects": len(unique_keys),
+            "updated_entries": updated_entries,
+            "rows": rows,
+        },
+    )
+    write_csv(audit_csv_path, rows)
+
+    available = sum(1 for row in rows if row["status"] == "available")
+    missing_or_inaccessible = len(rows) - available
+    return {
+        "expected_rows": len(expected),
+        "expected_projects": len(unique_keys),
+        "queried": len(rows),
+        "available": available,
+        "missing_or_inaccessible": missing_or_inaccessible,
+        "updated_entries": updated_entries,
+        "audit_path": str(audit_path),
+        "audit_csv_path": str(audit_csv_path),
+    }
+
+
+def discover_expected_projects(runs_root: Path) -> list[ExpectedProject]:
+    expected: list[ExpectedProject] = []
+    for agent, run_id in batch_scope.scoped_run_ids():
+        run_root = runs_root / run_id
+        if not run_root.is_dir():
+            continue
+        for variant, steps in export_bundle.VARIANT_STEPS.items():
+            step = str(steps["lidskjalv"])
+            project_key = project_key_for_step(run_root, step)
+            if project_key is None:
+                continue
+            expected.append(
+                ExpectedProject(
+                    agent=agent,
+                    run_id=run_id,
+                    variant=variant,
+                    step=step,
+                    project_key=project_key,
+                )
+            )
+    return expected
+
+
+def project_key_for_step(run_root: Path, step: str) -> str | None:
+    report = export_bundle.load_json(export_bundle.service_report_path(run_root, step))
+    project_key = export_bundle.non_empty_str(report.get("project_key"))
+    if project_key is not None:
+        return project_key
+    project_key = export_bundle.sonar_project_key_from_follow_up(run_root, step)
+    if project_key is not None:
+        return project_key
+    return export_bundle.service_manifest_project_key(run_root, step)
+
+
+def discover_follow_up_destinations(
+    runs_root: Path, sonar_sidecar_root: Path
+) -> list[FollowUpDestination]:
+    destinations: list[FollowUpDestination] = []
+    for _, run_id in batch_scope.scoped_run_ids():
+        path = runs_root / run_id / "pipeline" / "outputs" / "sonar_follow_up.json"
+        if path.is_file():
+            destinations.append(FollowUpDestination(path=path, source="run_follow_up"))
+    for path in sorted(
+        (sonar_sidecar_root / "follow_up").glob("*/sonar_follow_up.json")
+    ):
+        destinations.append(FollowUpDestination(path=path, source="sidecar_follow_up"))
+    return destinations
+
+
+def index_destinations_by_project(
+    destinations: Sequence[FollowUpDestination],
+) -> dict[str, list[FollowUpDestination]]:
+    indexed: dict[str, list[FollowUpDestination]] = defaultdict(list)
+    for destination in destinations:
+        document = load_json(destination.path)
+        for raw_entry in mapping(document.get("steps")).values():
+            project_key = non_empty_str(mapping(raw_entry).get("project_key"))
+            if project_key is not None:
+                indexed[project_key].append(destination)
+    return indexed
+
+
+def fetch_project_metrics(
+    project_key: str,
+    *,
+    sonar_host_url: str,
+    sonar_token: str,
+    require_all_metrics: bool,
+) -> dict[str, object]:
+    metric_keys = metric_key_list()
+    try:
+        measures_raw = _sonar_api_get_json(
+            sonar_host_url,
+            sonar_token,
+            "/api/measures/component",
+            {"component": project_key, "metricKeys": ",".join(metric_keys)},
+        )
+        qg_raw = _sonar_api_get_json(
+            sonar_host_url,
+            sonar_token,
+            "/api/qualitygates/project_status",
+            {"projectKey": project_key},
+        )
+    except RuntimeError as exc:
+        return {
+            "project_key": project_key,
+            "status": "missing_or_inaccessible",
+            "quality_gate_status": None,
+            "measures": {},
+            "missing_metrics": metric_keys,
+            "error": str(exc),
+        }
+
+    measures = _extract_measures(measures_raw)
+    missing_metrics = [metric for metric in metric_keys if metric not in measures]
+    if require_all_metrics and missing_metrics:
+        status = "partial"
+    else:
+        status = "available" if measures else "missing_or_inaccessible"
+    return {
+        "project_key": project_key,
+        "status": status,
+        "quality_gate_status": non_empty_str(
+            mapping(qg_raw.get("projectStatus")).get("status")
+        ),
+        "measures": measures,
+        "missing_metrics": missing_metrics,
+        "error": None,
+    }
+
+
+def apply_metric_updates(
+    destinations: Sequence[FollowUpDestination],
+    fetched: Mapping[str, Mapping[str, object]],
+) -> int:
+    updated_entries = 0
+    checked_at = timestamp_utc()
+    for destination in destinations:
+        document = load_json(destination.path)
+        steps = mapping(document.get("steps"))
+        if not steps:
+            continue
+        changed = False
+        new_steps: dict[str, object] = {}
+        for step, raw_entry in steps.items():
+            entry = dict(mapping(raw_entry))
+            project_key = non_empty_str(entry.get("project_key"))
+            project = fetched.get(project_key or "")
+            if project and project.get("status") == "available":
+                measures = dict(mapping(project.get("measures")))
+                entry["measures"] = measures
+                entry["quality_gate_status"] = project.get("quality_gate_status")
+                entry["data_status"] = "complete" if measures else "unavailable"
+                entry["status"] = "complete" if measures else "pending"
+                entry["reason"] = None if measures else entry.get("reason")
+                entry["last_checked_at"] = checked_at
+                entry["last_error"] = None
+                if entry != raw_entry:
+                    changed = True
+                    updated_entries += 1
+            new_steps[str(step)] = entry
+        if changed:
+            document["steps"] = new_steps
+            document["status"] = overall_status(new_steps.values())
+            document["updated_at"] = checked_at
+            write_json(destination.path, document)
+    return updated_entries
+
+
+def overall_status(entries: Any) -> str:
+    statuses = [
+        non_empty_str(mapping(entry).get("status")) or "pending" for entry in entries
+    ]
+    if not statuses:
+        return "skipped"
+    if any(status == "failed" for status in statuses):
+        return "failed"
+    if any(status == "pending" for status in statuses):
+        return "pending"
+    if all(status == "skipped" for status in statuses):
+        return "skipped"
+    return "complete"
+
+
+def metric_key_list() -> list[str]:
+    return [key.strip() for key in SONAR_MEASURE_KEYS.split(",") if key.strip()]
+
+
+def load_json(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_csv(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    fieldnames = [
+        "project_key",
+        "status",
+        "quality_gate_status",
+        "metric_count",
+        "missing_metrics",
+        "error",
+        "destination_count",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key) for key in fieldnames})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/backfill_sonar_resubmissions.py
+++ b/scripts/backfill_sonar_resubmissions.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import sys
+import time
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from heimdall.models import (  # noqa: E402
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+    STEP_LIDSKJALV_ORIGINAL,
+)
+from heimdall.sonar_follow_up import (  # noqa: E402
+    SONAR_FOLLOW_UP_SCHEMA_VERSION,
+    SONAR_MEASURE_KEYS,
+    load_sonar_follow_up,
+    update_sonar_follow_up,
+)
+from heimdall.utils import timestamp_utc  # noqa: E402
+
+
+DEFAULT_OUTPUT_ROOT = Path("/srv/pipeline/retries/sonar-resubmission")
+FOLLOW_UP_DIRNAME = "follow_up"
+LIDSKJALV_STEPS = (
+    STEP_LIDSKJALV_ORIGINAL,
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Backfill SonarCloud metrics for sidecar Sonar resubmissions without "
+            "modifying original pipeline run directories."
+        )
+    )
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="Poll once and exit. Without this flag, poll until all entries are terminal.",
+    )
+    parser.add_argument("--poll-interval-sec", type=float, default=30.0)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    successes = discover_successful_submissions(args.output_root)
+    if not successes:
+        print("No successful sidecar submissions found.")
+        return 0
+
+    if args.dry_run:
+        for success in successes:
+            print(
+                f"{success['run_id']}\t{success['step']}\t"
+                f"{success['project_key']}\t{success['sonar_task_id']}"
+            )
+        print(f"Selected {len(successes)} successful sidecar submission(s).")
+        return 0
+
+    sonar_host_url = os.environ.get("SONAR_HOST_URL")
+    sonar_token = os.environ.get("SONAR_TOKEN")
+    missing = [
+        name
+        for name, value in {
+            "SONAR_HOST_URL": sonar_host_url,
+            "SONAR_TOKEN": sonar_token,
+        }.items()
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Missing required Sonar environment variable(s): {', '.join(missing)}"
+        )
+    assert sonar_host_url is not None
+    assert sonar_token is not None
+
+    while True:
+        follow_up_paths = sync_sidecar_follow_up(args.output_root, successes)
+        for path in follow_up_paths:
+            update_sonar_follow_up(
+                path,
+                sonar_host_url=sonar_host_url,
+                sonar_token=sonar_token,
+            )
+        rows = write_metric_exports(args.output_root, follow_up_paths)
+        pending = [row for row in rows if row.get("status") == "pending"]
+        print(f"Backfilled {len(rows)} sidecar submission(s); pending={len(pending)}.")
+        if args.once or not pending:
+            return 0 if not pending else 1
+        time.sleep(args.poll_interval_sec)
+
+
+def discover_successful_submissions(output_root: Path) -> list[dict[str, object]]:
+    successes: dict[tuple[str, str], dict[str, object]] = {}
+    for summary_path in sorted(output_root.glob("*/*/*attempt-*/summary.json")):
+        summary = load_optional_json(summary_path)
+        if summary.get("submission_success") is not True:
+            continue
+        run_id = non_empty_str(summary.get("run_id"))
+        step = non_empty_str(summary.get("step"))
+        sonar_task_id = non_empty_str(summary.get("sonar_task_id"))
+        project_key = non_empty_str(summary.get("project_key"))
+        if None in {run_id, step, sonar_task_id, project_key}:
+            continue
+        assert run_id is not None
+        assert step is not None
+        key = (run_id, step)
+        successes[key] = {
+            "run_id": run_id,
+            "step": step,
+            "scan_label": non_empty_str(summary.get("scan_label"))
+            or scan_label_for_step(step),
+            "variant": non_empty_str(summary.get("variant")) or variant_for_step(step),
+            "project_key": project_key,
+            "project_name": non_empty_str(summary.get("project_name")),
+            "sonar_task_id": sonar_task_id,
+            "attempt_type": non_empty_str(summary.get("attempt_type")),
+            "attempt_dir": non_empty_str(summary.get("attempt_dir")),
+            "summary_path": str(summary_path),
+        }
+    return [successes[key] for key in sorted(successes)]
+
+
+def sync_sidecar_follow_up(
+    output_root: Path, successes: Sequence[Mapping[str, object]]
+) -> list[Path]:
+    by_run: dict[str, list[Mapping[str, object]]] = defaultdict(list)
+    for success in successes:
+        run_id = non_empty_str(success.get("run_id"))
+        if run_id is not None:
+            by_run[run_id].append(success)
+
+    paths: list[Path] = []
+    for run_id, entries in sorted(by_run.items()):
+        path = sidecar_follow_up_path(output_root, run_id)
+        existing = load_optional_json(path)
+        existing_steps = mapping(existing.get("steps"))
+        step_docs = {
+            non_empty_str(entry.get("step")) or "unknown": build_step_document(
+                entry,
+                mapping(existing_steps.get(non_empty_str(entry.get("step")) or "")),
+            )
+            for entry in sorted(entries, key=lambda item: str(item.get("step")))
+        }
+        document = {
+            "schema_version": SONAR_FOLLOW_UP_SCHEMA_VERSION,
+            "sidecar_schema_version": "heimdall_sonar_resubmission_follow_up.v1",
+            "run_id": run_id,
+            "status": overall_status(step_docs.values()),
+            "updated_at": timestamp_utc(),
+            "steps": step_docs,
+        }
+        write_json(path, document)
+        paths.append(path)
+    return paths
+
+
+def build_step_document(
+    success: Mapping[str, object], existing: Mapping[str, object]
+) -> dict[str, object]:
+    step = non_empty_str(success.get("step")) or "unknown"
+    project_key = non_empty_str(success.get("project_key"))
+    sonar_task_id = non_empty_str(success.get("sonar_task_id"))
+    if (
+        existing
+        and non_empty_str(existing.get("sonar_task_id")) == sonar_task_id
+        and non_empty_str(existing.get("status")) in {"pending", "complete", "failed"}
+    ):
+        document = dict(existing)
+        document.update(
+            {
+                "step": step,
+                "project_key": project_key,
+                "scan_label": non_empty_str(success.get("scan_label"))
+                or scan_label_for_step(step),
+                "sonar_task_id": sonar_task_id,
+            }
+        )
+        return document
+    return {
+        "step": step,
+        "project_key": project_key,
+        "scan_label": non_empty_str(success.get("scan_label"))
+        or scan_label_for_step(step),
+        "sonar_task_id": sonar_task_id,
+        "status": "pending",
+        "reason": None,
+        "ce_task_status": None,
+        "quality_gate_status": None,
+        "data_status": "pending",
+        "measures": {},
+        "last_checked_at": None,
+        "last_error": None,
+        "attempt_type": non_empty_str(success.get("attempt_type")),
+        "attempt_dir": non_empty_str(success.get("attempt_dir")),
+    }
+
+
+def write_metric_exports(
+    output_root: Path, follow_up_paths: Sequence[Path]
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    metric_keys = [key.strip() for key in SONAR_MEASURE_KEYS.split(",") if key.strip()]
+    for path in follow_up_paths:
+        document = load_sonar_follow_up(path)
+        run_id = non_empty_str(document.get("run_id")) or path.parent.name
+        for step, raw_entry in sorted(mapping(document.get("steps")).items()):
+            entry = mapping(raw_entry)
+            measures = mapping(entry.get("measures"))
+            row: dict[str, object] = {
+                "run_id": run_id,
+                "step": step,
+                "scan_label": non_empty_str(entry.get("scan_label")),
+                "variant": variant_for_step(step),
+                "project_key": non_empty_str(entry.get("project_key")),
+                "sonar_task_id": non_empty_str(entry.get("sonar_task_id")),
+                "status": non_empty_str(entry.get("status")),
+                "reason": non_empty_str(entry.get("reason")),
+                "ce_task_status": non_empty_str(entry.get("ce_task_status")),
+                "quality_gate_status": non_empty_str(entry.get("quality_gate_status")),
+                "data_status": non_empty_str(entry.get("data_status")),
+                "last_checked_at": non_empty_str(entry.get("last_checked_at")),
+                "last_error": non_empty_str(entry.get("last_error")),
+                "follow_up_path": str(path),
+            }
+            for metric in metric_keys:
+                row[metric] = non_empty_str(measures.get(metric))
+            rows.append(row)
+
+    write_json(
+        output_root / "metrics.json",
+        {
+            "schema_version": "heimdall_sonar_resubmission_metrics.v1",
+            "generated_at": timestamp_utc(),
+            "row_count": len(rows),
+            "rows": rows,
+        },
+    )
+    write_metrics_csv(output_root / "metrics.csv", rows, metric_keys)
+    return rows
+
+
+def write_metrics_csv(
+    path: Path, rows: Sequence[Mapping[str, object]], metric_keys: Sequence[str]
+) -> None:
+    fieldnames = [
+        "run_id",
+        "step",
+        "scan_label",
+        "variant",
+        "project_key",
+        "sonar_task_id",
+        "status",
+        "reason",
+        "ce_task_status",
+        "quality_gate_status",
+        "data_status",
+        "last_checked_at",
+        "last_error",
+        *metric_keys,
+        "follow_up_path",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key) for key in fieldnames})
+
+
+def sidecar_follow_up_path(output_root: Path, run_id: str) -> Path:
+    return output_root / FOLLOW_UP_DIRNAME / run_id / "sonar_follow_up.json"
+
+
+def overall_status(entries: Any) -> str:
+    statuses = [
+        non_empty_str(mapping(entry).get("status")) or "pending" for entry in entries
+    ]
+    if not statuses:
+        return "skipped"
+    if any(status == "failed" for status in statuses):
+        return "failed"
+    if any(status == "pending" for status in statuses):
+        return "pending"
+    return "complete"
+
+
+def scan_label_for_step(step: str) -> str:
+    if step == STEP_LIDSKJALV_GENERATED:
+        return "generated"
+    if step == STEP_LIDSKJALV_GENERATED_V2:
+        return "generated-v2"
+    if step == STEP_LIDSKJALV_GENERATED_V3:
+        return "generated-v3"
+    return "original"
+
+
+def variant_for_step(step: str) -> str:
+    if step == STEP_LIDSKJALV_GENERATED:
+        return "generated"
+    if step == STEP_LIDSKJALV_GENERATED_V2:
+        return "v2"
+    if step == STEP_LIDSKJALV_GENERATED_V3:
+        return "v3"
+    return "original"
+
+
+def load_optional_json(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_analysis_bundle.py
+++ b/scripts/export_analysis_bundle.py
@@ -1,0 +1,801 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import shutil
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+from heimdall.simpleyaml import loads  # noqa: E402
+from heimdall.utils import compact_run_id, timestamp_utc  # noqa: E402
+
+import resubmit_missing_sonar as batch_scope  # noqa: E402
+
+
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+DEFAULT_SONAR_SIDECAR_ROOT = Path("/srv/pipeline/retries/sonar-resubmission")
+DEFAULT_EXPORT_ROOT = Path("/srv/pipeline/exports")
+VARIANTS = ("original", "generated", "v2", "v3")
+VARIANT_STEPS = {
+    "original": {
+        "lidskjalv": "lidskjalv-original",
+        "mimir": None,
+        "kvasir": None,
+    },
+    "generated": {
+        "lidskjalv": "lidskjalv-generated",
+        "mimir": "mimir",
+        "kvasir": "kvasir",
+    },
+    "v2": {
+        "lidskjalv": "lidskjalv-generated-v2",
+        "mimir": "mimir-v2",
+        "kvasir": "kvasir-v2",
+    },
+    "v3": {
+        "lidskjalv": "lidskjalv-generated-v3",
+        "mimir": "mimir-v3",
+        "kvasir": "kvasir-v3",
+    },
+}
+SONAR_METRICS = (
+    "bugs",
+    "vulnerabilities",
+    "code_smells",
+    "security_hotspots",
+    "files",
+    "classes",
+    "functions",
+    "statements",
+    "ncloc",
+    "sqale_index",
+    "duplicated_files",
+    "duplicated_lines",
+    "duplicated_blocks",
+    "blocker_violations",
+    "critical_violations",
+    "major_violations",
+    "minor_violations",
+    "info_violations",
+    "coverage",
+    "duplicated_lines_density",
+    "reliability_rating",
+    "security_rating",
+    "sqale_rating",
+    "complexity",
+    "cognitive_complexity",
+    "comment_lines",
+    "comment_lines_density",
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Export Mimir stats, Kvasir reports, and Lidskjalv/Sonar metrics for "
+            "the current Codex/Claude experiment batch."
+        )
+    )
+    parser.add_argument("--runs-root", type=Path, default=DEFAULT_RUNS_ROOT)
+    parser.add_argument(
+        "--sonar-sidecar-root", type=Path, default=DEFAULT_SONAR_SIDECAR_ROOT
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help=(
+            "Bundle destination. Defaults to "
+            "/srv/pipeline/exports/heimdall-analysis-<timestamp>."
+        ),
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Allow writing into an existing output directory.",
+    )
+    parser.add_argument(
+        "--include-raw",
+        action="store_true",
+        help="Also copy raw source reports for provenance/debugging.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    output_dir = args.output_dir or (
+        DEFAULT_EXPORT_ROOT / f"heimdall-analysis-{compact_run_id()}"
+    )
+    if output_dir.exists() and not args.force:
+        raise RuntimeError(f"Output directory already exists: {output_dir}")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    bundle = build_bundle(
+        runs_root=args.runs_root,
+        sonar_sidecar_root=args.sonar_sidecar_root,
+        output_dir=output_dir,
+        copy_raw=args.include_raw,
+    )
+    write_bundle(output_dir, bundle)
+    print(f"Wrote analysis bundle: {output_dir}")
+    print(
+        f"runs={len(bundle['runs'])} variants={len(bundle['variants'])} "
+        f"sonar_projects={len(bundle['sonar_projects'])}"
+    )
+    return 0
+
+
+def build_bundle(
+    *,
+    runs_root: Path,
+    sonar_sidecar_root: Path,
+    output_dir: Path,
+    copy_raw: bool,
+) -> dict[str, list[dict[str, object]]]:
+    run_rows: list[dict[str, object]] = []
+    variant_rows: list[dict[str, object]] = []
+    mimir_rows: list[dict[str, object]] = []
+    kvasir_rows: list[dict[str, object]] = []
+    sonar_candidates = collect_sonar_candidates(runs_root, sonar_sidecar_root)
+    sonar_by_project = choose_sonar_projects(sonar_candidates)
+
+    for agent, run_id in batch_scope.scoped_run_ids():
+        run_root = runs_root / run_id
+        if not run_root.is_dir():
+            continue
+        run_row = build_run_row(agent, run_root)
+        run_rows.append(run_row)
+        for variant in VARIANTS:
+            variant_row = build_variant_row(
+                agent=agent,
+                run_root=run_root,
+                variant=variant,
+                sonar_by_project=sonar_by_project,
+            )
+            variant_rows.append(variant_row)
+            if mimir_report_exists(run_root, variant):
+                mimir_rows.append(build_mimir_row(agent, run_root, variant))
+            if kvasir_report_exists(run_root, variant):
+                kvasir_rows.append(build_kvasir_row(agent, run_root, variant))
+        if copy_raw:
+            copy_raw_run_reports(output_dir, agent, run_root)
+
+    if copy_raw:
+        copy_raw_sidecar_reports(output_dir, sonar_sidecar_root)
+
+    valid_sonar_project_keys = {
+        str(row["project_key"]) for row in variant_rows if row.get("project_key")
+    }
+    sonar_agent_by_project = sonar_agent_map(variant_rows)
+    sonar_project_rows = [
+        build_sonar_project_row(key, sonar_by_project[key], sonar_agent_by_project)
+        for key in sorted(valid_sonar_project_keys)
+        if key in sonar_by_project
+    ]
+    return {
+        "runs": run_rows,
+        "variants": variant_rows,
+        "mimir": mimir_rows,
+        "kvasir": kvasir_rows,
+        "sonar_projects": sonar_project_rows,
+    }
+
+
+def build_run_row(agent: str, run_root: Path) -> dict[str, object]:
+    manifest = load_yaml(run_root / "pipeline" / "manifest.yaml")
+    report = load_json(run_root / "pipeline" / "outputs" / "run_report.json")
+    source = mapping(manifest.get("source"))
+    return {
+        "agent": agent,
+        "run_id": run_root.name,
+        "repo_slug": repo_slug_from_run_id(run_root.name),
+        "repo_url": non_empty_str(source.get("repo_url")),
+        "commit_sha": non_empty_str(source.get("commit_sha")),
+        "status": non_empty_str(report.get("status")),
+    }
+
+
+def build_variant_row(
+    *,
+    agent: str,
+    run_root: Path,
+    variant: str,
+    sonar_by_project: Mapping[str, Mapping[str, object]],
+) -> dict[str, object]:
+    steps = VARIANT_STEPS[variant]
+    lidskjalv_step = str(steps["lidskjalv"])
+    mimir_step = steps["mimir"]
+    kvasir_step = steps["kvasir"]
+    state = load_pipeline_state(run_root)
+    if variant == "original":
+        andvari_status, andvari_reason = (None, None)
+        mimir_status, mimir_reason = (None, None)
+        kvasir_status, kvasir_reason = (None, None)
+    else:
+        andvari_status, andvari_reason = service_status_reason(
+            run_root,
+            andvari_step_for_variant(variant),
+            state,
+            "run_report",
+        )
+        mimir_status, mimir_reason = (
+            service_status_reason(run_root, str(mimir_step), state, "run_report")
+            if mimir_step is not None
+            else (None, None)
+        )
+        kvasir_status, kvasir_reason = (
+            service_status_reason(run_root, str(kvasir_step), state, "kvasir_report")
+            if kvasir_step is not None
+            else (None, None)
+        )
+    lidskjalv_status, lidskjalv_reason = service_status_reason(
+        run_root,
+        lidskjalv_step,
+        state,
+        "run_report",
+    )
+    project_key = valid_sonar_project_key(run_root, lidskjalv_step, sonar_by_project)
+    return {
+        "agent": agent,
+        "run_id": run_root.name,
+        "repo_slug": repo_slug_from_run_id(run_root.name),
+        "variant": variant,
+        "andvari_status": andvari_status,
+        "andvari_reason": andvari_reason,
+        "mimir_status": mimir_status,
+        "mimir_reason": mimir_reason,
+        "kvasir_status": kvasir_status,
+        "kvasir_reason": kvasir_reason,
+        "lidskjalv_status": lidskjalv_status,
+        "lidskjalv_reason": lidskjalv_reason,
+        "project_key": project_key,
+    }
+
+
+def build_mimir_row(agent: str, run_root: Path, variant: str) -> dict[str, object]:
+    step = str(VARIANT_STEPS[variant]["mimir"])
+    path = service_report_path(run_root, step)
+    report = load_json(path)
+    comparison = first_comparison(report)
+    diff_counts = mapping(comparison.get("diff_counts"))
+    component_scores = mapping(comparison.get("component_scores"))
+    component_exact = mapping(component_scores.get("exact"))
+    component_fuzzy = mapping(component_scores.get("fuzzy"))
+    row = {
+        "agent": agent,
+        "run_id": run_root.name,
+        "repo_slug": repo_slug_from_run_id(run_root.name),
+        "variant": variant,
+        "exact_similarity": comparison.get("exact_similarity"),
+        "fuzzy_similarity": comparison.get("fuzzy_similarity"),
+        "component_exact_packages": component_exact.get("packages"),
+        "component_exact_types": component_exact.get("types"),
+        "component_exact_fields": component_exact.get("fields"),
+        "component_exact_methods": component_exact.get("methods"),
+        "component_exact_relations": component_exact.get("relations"),
+        "component_fuzzy_matched_type_coverage": component_fuzzy.get(
+            "matched_type_coverage"
+        ),
+        "component_fuzzy_field_preservation": component_fuzzy.get("field_preservation"),
+        "component_fuzzy_method_preservation": component_fuzzy.get(
+            "method_preservation"
+        ),
+        "component_fuzzy_relation_preservation": component_fuzzy.get(
+            "relation_preservation"
+        ),
+        "component_fuzzy_name_package_retention": component_fuzzy.get(
+            "name_package_retention"
+        ),
+    }
+    for key in (
+        "missing_packages",
+        "added_packages",
+        "missing_types",
+        "added_types",
+        "likely_renamed_or_moved_types",
+        "missing_fields",
+        "added_fields",
+        "changed_fields",
+        "missing_methods",
+        "added_methods",
+        "changed_methods",
+        "missing_relations",
+        "added_relations",
+        "changed_relations",
+    ):
+        row[key] = diff_counts.get(key)
+    return row
+
+
+def build_kvasir_row(agent: str, run_root: Path, variant: str) -> dict[str, object]:
+    step = str(VARIANT_STEPS[variant]["kvasir"])
+    path = kvasir_report_path(run_root, step)
+    report = load_json(path)
+    result = mapping(report.get("result"))
+    evidence = mapping(report.get("evidence"))
+    behavioral = mapping(evidence.get("behavioral"))
+    suite_changes = mapping(evidence.get("suite_changes"))
+    retention = mapping(evidence.get("retention"))
+    diagnostics = mapping(report.get("diagnostics"))
+    write_scope = mapping(diagnostics.get("write_scope"))
+    porting = mapping(report.get("porting"))
+    porting_execution = mapping(porting.get("execution"))
+    baselines = mapping(report.get("baselines"))
+    original_baseline = mapping(baselines.get("original"))
+    generated_baseline = mapping(baselines.get("generated"))
+    original_execution = mapping(original_baseline.get("execution"))
+    generated_execution = mapping(generated_baseline.get("execution"))
+    row = {
+        "agent": agent,
+        "run_id": run_root.name,
+        "repo_slug": repo_slug_from_run_id(run_root.name),
+        "variant": variant,
+        "status": non_empty_str(result.get("status")),
+        "reason": non_empty_str(result.get("reason")),
+        "verdict": non_empty_str(result.get("verdict")),
+        "verdict_reason": non_empty_str(result.get("verdict_reason")),
+        "failure_class": non_empty_str(result.get("failure_class")),
+        "original_baseline_status": non_empty_str(original_baseline.get("status")),
+        "generated_baseline_status": non_empty_str(generated_baseline.get("status")),
+        "porting_status": non_empty_str(porting.get("status")),
+        "behavioral_failing_case_count": behavioral.get("failing_case_count"),
+        "behavioral_failing_case_unique_count": behavioral.get(
+            "failing_case_unique_count"
+        ),
+        "behavioral_failing_case_occurrence_count": behavioral.get(
+            "failing_case_occurrence_count"
+        ),
+        "suite_added": suite_changes.get("added"),
+        "suite_modified": suite_changes.get("modified"),
+        "suite_deleted": suite_changes.get("deleted"),
+        "suite_total": suite_changes.get("total"),
+        "retention_original_snapshot_file_count": retention.get(
+            "original_snapshot_file_count"
+        ),
+        "retention_final_ported_test_file_count": retention.get(
+            "final_ported_test_file_count"
+        ),
+        "retention_retained_original_test_file_count": retention.get(
+            "retained_original_test_file_count"
+        ),
+        "retention_removed_original_test_file_count": retention.get(
+            "removed_original_test_file_count"
+        ),
+        "retention_ratio": retention.get("retention_ratio"),
+        "write_scope_violation_count": write_scope.get("violation_count"),
+    }
+    add_execution_counts(row, "original_baseline", original_execution)
+    add_execution_counts(row, "generated_baseline", generated_execution)
+    add_execution_counts(row, "porting", porting_execution)
+    return row
+
+
+def andvari_step_for_variant(variant: str) -> str:
+    if variant == "v2":
+        return "andvari-v2"
+    if variant == "v3":
+        return "andvari-v3"
+    return "andvari"
+
+
+def load_pipeline_state(run_root: Path) -> Mapping[str, object]:
+    payload = load_json(run_root / "pipeline" / "state.json")
+    steps = mapping(payload.get("steps"))
+    return steps if steps else payload
+
+
+def service_status_reason(
+    run_root: Path,
+    step: str,
+    state: Mapping[str, object],
+    report_kind: str,
+) -> tuple[str | None, str | None]:
+    report = load_service_status_report(run_root, step, report_kind)
+    if report:
+        if report_kind == "kvasir_report":
+            result = mapping(report.get("result"))
+            return non_empty_str(result.get("status")), non_empty_str(
+                result.get("reason")
+            )
+        return non_empty_str(report.get("status")), non_empty_str(report.get("reason"))
+    state_entry = mapping(state.get(step))
+    return non_empty_str(state_entry.get("status")), non_empty_str(
+        state_entry.get("reason")
+    )
+
+
+def load_service_status_report(
+    run_root: Path, step: str, report_kind: str
+) -> Mapping[str, object]:
+    if report_kind == "kvasir_report":
+        return load_json(kvasir_report_path(run_root, step))
+    return load_json(service_report_path(run_root, step))
+
+
+def valid_sonar_project_key(
+    run_root: Path,
+    lidskjalv_step: str,
+    sonar_by_project: Mapping[str, Mapping[str, object]],
+) -> str | None:
+    report = load_json(service_report_path(run_root, lidskjalv_step))
+    if not report:
+        state = load_pipeline_state(run_root)
+        state_status = non_empty_str(mapping(state.get(lidskjalv_step)).get("status"))
+        if state_status in {"blocked", "skipped"}:
+            return None
+
+    for project_key in candidate_sonar_project_keys(run_root, lidskjalv_step):
+        if project_key in sonar_by_project:
+            return project_key
+    return None
+
+
+def candidate_sonar_project_keys(run_root: Path, step: str) -> list[str]:
+    candidates: list[str] = []
+    report = load_json(service_report_path(run_root, step))
+    report_key = non_empty_str(report.get("project_key"))
+    if report_key is not None:
+        candidates.append(report_key)
+
+    document = load_json(run_root / "pipeline" / "outputs" / "sonar_follow_up.json")
+    entry = mapping(mapping(document.get("steps")).get(step))
+    follow_up_key = non_empty_str(entry.get("project_key"))
+    if follow_up_key is not None:
+        candidates.append(follow_up_key)
+
+    manifest_key = service_manifest_project_key(run_root, step)
+    if manifest_key is not None:
+        candidates.append(manifest_key)
+
+    return list(dict.fromkeys(candidates))
+
+
+def mimir_report_exists(run_root: Path, variant: str) -> bool:
+    step = VARIANT_STEPS[variant]["mimir"]
+    return step is not None and service_report_path(run_root, str(step)).is_file()
+
+
+def kvasir_report_exists(run_root: Path, variant: str) -> bool:
+    step = VARIANT_STEPS[variant]["kvasir"]
+    return step is not None and kvasir_report_path(run_root, str(step)).is_file()
+
+
+def add_execution_counts(
+    row: dict[str, object], prefix: str, execution: Mapping[str, object]
+) -> None:
+    for key in (
+        "tests_discovered",
+        "tests_executed",
+        "tests_failed",
+        "tests_errors",
+        "tests_skipped",
+    ):
+        row[f"{prefix}_{key}"] = execution.get(key)
+
+
+def collect_sonar_candidates(
+    runs_root: Path, sonar_sidecar_root: Path
+) -> list[dict[str, object]]:
+    candidates: list[dict[str, object]] = []
+    for agent, run_id in batch_scope.scoped_run_ids():
+        path = runs_root / run_id / "pipeline" / "outputs" / "sonar_follow_up.json"
+        candidates.extend(
+            read_sonar_follow_up(path, source="run_follow_up", agent=agent)
+        )
+
+    for path in sorted(
+        (sonar_sidecar_root / "follow_up").glob("*/sonar_follow_up.json")
+    ):
+        candidates.extend(
+            read_sonar_follow_up(path, source="sidecar_follow_up", agent=None)
+        )
+
+    return candidates
+
+
+def read_sonar_follow_up(
+    path: Path, *, source: str, agent: str | None
+) -> list[dict[str, object]]:
+    document = load_json(path)
+    if not document:
+        return []
+    run_id = non_empty_str(document.get("run_id")) or path.parent.name
+    rows: list[dict[str, object]] = []
+    for step, raw_entry in mapping(document.get("steps")).items():
+        entry = mapping(raw_entry)
+        project_key = non_empty_str(entry.get("project_key"))
+        if not project_key:
+            continue
+        measures = mapping(entry.get("measures"))
+        row = {
+            "repo_slug": repo_slug_from_run_id(run_id),
+            "variant": variant_for_lidskjalv_step(step),
+            "project_key": project_key,
+        }
+        row.update(
+            {metric: non_empty_str(measures.get(metric)) for metric in SONAR_METRICS}
+        )
+        rows.append(row)
+    return rows
+
+
+def build_sonar_project_row(
+    project_key: str,
+    sonar: Mapping[str, object],
+    agent_by_project: Mapping[str, str | None],
+) -> dict[str, object]:
+    variant = non_empty_str(sonar.get("variant"))
+    row: dict[str, object] = {
+        "agent": agent_by_project.get(project_key),
+        "project_key": project_key,
+        "repo_slug": non_empty_str(sonar.get("repo_slug")),
+        "variant": variant,
+    }
+    row.update({metric: sonar.get(metric) for metric in SONAR_METRICS})
+    return row
+
+
+def sonar_agent_map(
+    variant_rows: Sequence[Mapping[str, object]],
+) -> dict[str, str | None]:
+    agents_by_project: dict[str, set[str]] = {}
+    variants_by_project: dict[str, set[str]] = {}
+    for row in variant_rows:
+        project_key = non_empty_str(row.get("project_key"))
+        if project_key is None:
+            continue
+        agents_by_project.setdefault(project_key, set()).add(str(row.get("agent")))
+        variants_by_project.setdefault(project_key, set()).add(str(row.get("variant")))
+
+    result: dict[str, str | None] = {}
+    for project_key, agents in agents_by_project.items():
+        variants = variants_by_project.get(project_key, set())
+        if variants == {"original"}:
+            result[project_key] = None
+        elif len(agents) == 1:
+            result[project_key] = next(iter(agents))
+        else:
+            result[project_key] = None
+    return result
+
+
+def choose_sonar_projects(
+    candidates: Sequence[Mapping[str, object]],
+) -> dict[str, dict[str, object]]:
+    selected: dict[str, dict[str, object]] = {}
+    for candidate in candidates:
+        project_key = non_empty_str(candidate.get("project_key"))
+        if not project_key:
+            continue
+        current = selected.get(project_key)
+        if current is None or sonar_rank(candidate) > sonar_rank(current):
+            selected[project_key] = dict(candidate)
+    return selected
+
+
+def sonar_rank(row: Mapping[str, object]) -> tuple[int, str, str]:
+    status = non_empty_str(row.get("status"))
+    has_metrics = any(
+        non_empty_str(row.get(metric)) is not None for metric in SONAR_METRICS
+    )
+    has_task = non_empty_str(row.get("sonar_task_id")) is not None
+    source = non_empty_str(row.get("source")) or ""
+    if status == "complete" and has_metrics:
+        score = 5
+    elif status == "complete":
+        score = 4
+    elif has_task and has_metrics:
+        score = 3
+    elif has_task:
+        score = 2
+    else:
+        score = 1
+    return (score, non_empty_str(row.get("last_checked_at")) or "", source)
+
+
+def write_bundle(
+    output_dir: Path, bundle: Mapping[str, Sequence[Mapping[str, object]]]
+) -> None:
+    tables_dir = output_dir / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    for name, rows in bundle.items():
+        write_jsonl(tables_dir / f"{name}.jsonl", rows)
+        write_csv(tables_dir / f"{name}.csv", rows)
+
+    manifest = {
+        "schema_version": "heimdall_analysis_bundle.v1",
+        "generated_at": timestamp_utc(),
+        "run_count": len(bundle["runs"]),
+        "variant_count": len(bundle["variants"]),
+        "sonar_project_count": len(bundle["sonar_projects"]),
+        "tables": sorted(bundle),
+        "notes": [
+            "variants is the primary denormalized analysis table.",
+            "sonar_projects is deduplicated by project_key.",
+            "Original Sonar project keys are shared across Codex and Claude runs.",
+            "variants is the 320-row experiment matrix and carries tool status/reason columns.",
+            "Use non-empty variants.project_key to join valid Sonar metrics from sonar_projects.",
+            "sonar_projects excludes blocked variants that were accidentally scanned later.",
+            "mimir and kvasir contain only real tool report rows.",
+            "raw/ is included only when export runs with --include-raw.",
+        ],
+    }
+    write_json(output_dir / "manifest.json", manifest)
+    write_readme(output_dir)
+
+
+def write_readme(output_dir: Path) -> None:
+    (output_dir / "README.md").write_text(
+        "\n".join(
+            [
+                "# Heimdall Analysis Bundle",
+                "",
+                "Primary tables are in `tables/` as both CSV and JSONL.",
+                "",
+                "- `runs`: one row per pipeline run.",
+                "- `variants`: one row per run variant: original, generated, v2, v3; use status/reason columns for coverage.",
+                "- `sonar_projects`: one row per valid deduplicated Sonar project key.",
+                "- `mimir`: extracted Mimir comparison stats for real Mimir reports only.",
+                "- `kvasir`: extracted Kvasir behavioral/test-porting stats for real Kvasir reports only.",
+                "",
+                "Use non-empty `variants.project_key` to join to `sonar_projects.project_key`.",
+                "Empty `variants.project_key` means there is no valid Sonar row for that observation.",
+                "Only original Sonar rows intentionally share project keys across Codex and Claude.",
+                "Generated, v2, and v3 rows are agent-specific Sonar submissions when project_key is present.",
+                "Raw reports are copied under `raw/` only when export runs with `--include-raw`.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def copy_raw_run_reports(output_dir: Path, agent: str, run_root: Path) -> None:
+    raw_root = output_dir / "raw" / "runs" / agent / run_root.name
+    raw_paths = [
+        run_root / "pipeline" / "manifest.yaml",
+        run_root / "pipeline" / "outputs" / "run_report.json",
+        run_root / "pipeline" / "outputs" / "summary.md",
+        run_root / "pipeline" / "outputs" / "sonar_follow_up.json",
+    ]
+    for variant in VARIANTS:
+        steps = VARIANT_STEPS[variant]
+        if steps["mimir"] is not None:
+            raw_paths.append(service_report_path(run_root, str(steps["mimir"])))
+        if steps["kvasir"] is not None:
+            raw_paths.append(kvasir_report_path(run_root, str(steps["kvasir"])))
+        raw_paths.append(service_report_path(run_root, str(steps["lidskjalv"])))
+    copy_existing_files(run_root, raw_root, raw_paths)
+
+
+def copy_raw_sidecar_reports(output_dir: Path, sidecar_root: Path) -> None:
+    if not sidecar_root.is_dir():
+        return
+    raw_root = output_dir / "raw" / "sidecar" / "sonar-resubmission"
+    paths = [
+        *sidecar_root.glob("*.json"),
+        *sidecar_root.glob("follow_up/*/sonar_follow_up.json"),
+        *sidecar_root.glob("*/*/*attempt-*/summary.json"),
+    ]
+    copy_existing_files(sidecar_root, raw_root, paths)
+
+
+def copy_existing_files(
+    source_root: Path, raw_root: Path, paths: Sequence[Path]
+) -> None:
+    for path in paths:
+        if not path.is_file():
+            continue
+        destination = raw_root / path.relative_to(source_root)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(path, destination)
+
+
+def service_report_path(run_root: Path, service: str) -> Path:
+    return run_root / "services" / service / "run" / "outputs" / "run_report.json"
+
+
+def kvasir_report_path(run_root: Path, service: str) -> Path:
+    return run_root / "services" / service / "run" / "outputs" / "test_port.json"
+
+
+def sonar_project_key_from_follow_up(run_root: Path, step: str) -> str | None:
+    path = run_root / "pipeline" / "outputs" / "sonar_follow_up.json"
+    document = load_json(path)
+    entry = mapping(mapping(document.get("steps")).get(step))
+    return non_empty_str(entry.get("project_key"))
+
+
+def service_manifest_project_key(run_root: Path, step: str) -> str | None:
+    manifest = load_yaml(run_root / "services" / step / "config" / "manifest.yaml")
+    return non_empty_str(manifest.get("project_key"))
+
+
+def first_comparison(report: Mapping[str, object]) -> Mapping[str, object]:
+    comparisons = mapping(report.get("diagram_comparisons"))
+    for value in comparisons.values():
+        if isinstance(value, Mapping):
+            return value
+    return {}
+
+
+def variant_for_lidskjalv_step(step: str) -> str:
+    for variant, steps in VARIANT_STEPS.items():
+        if steps["lidskjalv"] == step:
+            return variant
+    return "unknown"
+
+
+def sonar_scope_for_variant(variant: str) -> str:
+    return "shared_original" if variant == "original" else "agent_specific"
+
+
+def repo_slug_from_run_id(run_id: str) -> str:
+    parts = run_id.split("__")
+    if len(parts) < 3:
+        return run_id
+    return "__".join(parts[1:-1])
+
+
+def load_json(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def load_yaml(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    payload = loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_jsonl(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def write_csv(path: Path, rows: Sequence[Mapping[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = sorted({str(key) for row in rows for key in row})
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key) for key in fieldnames})
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/reconcile_sonar_follow_up.py
+++ b/scripts/reconcile_sonar_follow_up.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from heimdall.models import (  # noqa: E402
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+    STEP_LIDSKJALV_ORIGINAL,
+)
+from heimdall.reporting import load_report  # noqa: E402
+from heimdall.sonar_follow_up import (  # noqa: E402
+    load_sonar_follow_up,
+    sonar_follow_up_path,
+    sync_sonar_follow_up,
+    update_sonar_follow_up,
+)
+from heimdall.state import load_existing_state  # noqa: E402
+
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+LIDSKJALV_STEPS = (
+    STEP_LIDSKJALV_ORIGINAL,
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
+
+
+@dataclass(frozen=True)
+class TargetRun:
+    run_root: Path
+    selection_reason: str
+
+    @property
+    def run_id(self) -> str:
+        return self.run_root.name
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create missing Sonar follow-up documents and refresh pending Sonar "
+            "metrics for successful Lidskjalv submissions."
+        )
+    )
+    parser.add_argument(
+        "--runs-root",
+        type=Path,
+        default=DEFAULT_RUNS_ROOT,
+        help=f"Pipeline runs root (default: {DEFAULT_RUNS_ROOT})",
+    )
+    parser.add_argument(
+        "--run-id",
+        action="append",
+        dest="run_ids",
+        help="Limit processing to a specific run_id. Repeatable.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the runs that would be reconciled without contacting Sonar.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    targets = discover_target_runs(args.runs_root, tuple(args.run_ids or ()))
+    if not targets:
+        print("No pending or backfillable Sonar follow-up runs found.")
+        return 0
+
+    if args.dry_run:
+        for target in targets:
+            print(f"{target.run_id}\t{target.selection_reason}")
+        print(f"Selected {len(targets)} run(s).")
+        return 0
+
+    sonar_host_url = os.environ.get("SONAR_HOST_URL")
+    sonar_token = os.environ.get("SONAR_TOKEN")
+    missing = []
+    if not sonar_host_url:
+        missing.append("SONAR_HOST_URL")
+    if not sonar_token:
+        missing.append("SONAR_TOKEN")
+    if missing:
+        raise RuntimeError(
+            f"Missing Sonar environment variable(s): {', '.join(missing)}"
+        )
+    assert sonar_host_url is not None
+    assert sonar_token is not None
+
+    for target in targets:
+        result = process_target_run(
+            target,
+            sonar_host_url=sonar_host_url,
+            sonar_token=sonar_token,
+        )
+        print(
+            f"{result['run_id']}\t{result['selection_reason']}\t"
+            f"created={result['created']}\tchanged={result['changed']}\t"
+            f"status={result['status']}"
+        )
+    print(f"Processed {len(targets)} run(s).")
+    return 0
+
+
+def discover_target_runs(
+    runs_root: Path,
+    run_ids: tuple[str, ...] = (),
+) -> list[TargetRun]:
+    if not runs_root.is_dir():
+        raise RuntimeError(f"Runs root does not exist: {runs_root}")
+
+    selected_ids = set(run_ids)
+    targets: list[TargetRun] = []
+    for run_root in sorted(item for item in runs_root.iterdir() if item.is_dir()):
+        if selected_ids and run_root.name not in selected_ids:
+            continue
+        follow_up_path = sonar_follow_up_path(run_root)
+        if follow_up_path.is_file():
+            try:
+                document = load_sonar_follow_up(follow_up_path)
+            except Exception:
+                if run_has_successful_submission(run_root):
+                    targets.append(TargetRun(run_root, "invalid_follow_up"))
+                continue
+            if str(document.get("status")).strip() == "pending":
+                targets.append(TargetRun(run_root, "pending_follow_up"))
+            continue
+        if run_has_successful_submission(run_root):
+            targets.append(TargetRun(run_root, "missing_follow_up"))
+    return targets
+
+
+def process_target_run(
+    target: TargetRun,
+    *,
+    sonar_host_url: str,
+    sonar_token: str,
+) -> dict[str, object]:
+    path = sonar_follow_up_path(target.run_root)
+    created = False
+    if target.selection_reason != "pending_follow_up" or not path.is_file():
+        steps = load_existing_state(target.run_root / "pipeline" / "state.json")
+        if not steps:
+            raise RuntimeError(
+                f"Run is missing pipeline state needed to backfill follow-up: "
+                f"{target.run_root}"
+            )
+        sync_sonar_follow_up(target.run_root, target.run_id, steps)
+        created = True
+
+    changed = update_sonar_follow_up(
+        path,
+        sonar_host_url=sonar_host_url,
+        sonar_token=sonar_token,
+    )
+    document = load_sonar_follow_up(path)
+    return {
+        "run_id": target.run_id,
+        "selection_reason": target.selection_reason,
+        "created": created,
+        "changed": changed,
+        "status": document.get("status"),
+    }
+
+
+def run_has_successful_submission(run_root: Path) -> bool:
+    for step in LIDSKJALV_STEPS:
+        report_path = (
+            run_root / "services" / step / "run" / "outputs" / "run_report.json"
+        )
+        if not report_path.is_file():
+            continue
+        try:
+            report = load_report(report_path)
+        except RuntimeError:
+            continue
+        if str(report.get("status")).strip() != "passed":
+            continue
+        scan = report.get("scan")
+        if not isinstance(scan, dict):
+            continue
+        sonar_task_id = str(scan.get("sonar_task_id") or "").strip()
+        if sonar_task_id:
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/recover_manual_sonar_submissions.py
+++ b/scripts/recover_manual_sonar_submissions.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from heimdall.utils import timestamp_utc  # noqa: E402
+
+
+DEFAULT_OUTPUT_ROOT = Path("/srv/pipeline/retries/sonar-resubmission")
+TASK_ID_RE = re.compile(r"/api/ce/task\?id=([A-Za-z0-9_-]+)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Recover successful manual Sonar submissions from sidecar docker logs "
+            "when report-task.txt was not persisted."
+        )
+    )
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Update sidecar summary.json files. Without this, only report changes.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    results = discover_recoveries(args.output_root)
+    if args.apply:
+        for result in results:
+            if result["status"] == "recoverable":
+                apply_recovery(
+                    Path(str(result["summary_path"])), str(result["sonar_task_id"])
+                )
+        results = discover_recoveries(args.output_root)
+
+    audit = {
+        "schema_version": "heimdall_manual_sonar_recovery.v1",
+        "generated_at": timestamp_utc(),
+        "mode": "apply" if args.apply else "dry-run",
+        "recoverable_count": sum(
+            1 for item in results if item["status"] == "recoverable"
+        ),
+        "already_success_count": sum(
+            1 for item in results if item["status"] == "already_success"
+        ),
+        "true_failure_count": sum(
+            1 for item in results if item["status"] == "true_failure"
+        ),
+        "results": results,
+    }
+    audit_path = args.output_root / "recovered_manual_submissions.json"
+    write_json(audit_path, audit)
+
+    for result in results:
+        print(
+            f"{result['status']}\t{result.get('run_id') or ''}\t"
+            f"{result.get('step') or ''}\t{result.get('sonar_task_id') or ''}\t"
+            f"{result['summary_path']}"
+        )
+    print(f"Wrote audit: {audit_path}")
+    if not args.apply and audit["recoverable_count"]:
+        print("Run again with --apply to update recoverable sidecar summaries.")
+    return 0
+
+
+def discover_recoveries(output_root: Path) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for summary_path in sorted(output_root.glob("*/*/manual-attempt-*/summary.json")):
+        summary = load_json(summary_path)
+        docker_log_path = Path(
+            str(summary.get("docker_log_path") or summary_path.parent / "docker.log")
+        )
+        log_text = read_text(docker_log_path)
+        task_id = extract_task_id(log_text)
+        analysis_successful = "ANALYSIS SUCCESSFUL" in log_text
+        submission_success = summary.get("submission_success") is True
+        if submission_success and non_empty_str(summary.get("sonar_task_id")):
+            status = "already_success"
+            task_id = non_empty_str(summary.get("sonar_task_id")) or task_id
+        elif analysis_successful and task_id:
+            status = "recoverable"
+        else:
+            status = "true_failure"
+        results.append(
+            {
+                "status": status,
+                "run_id": non_empty_str(summary.get("run_id")),
+                "step": non_empty_str(summary.get("step")),
+                "project_key": non_empty_str(summary.get("project_key")),
+                "sonar_task_id": task_id,
+                "analysis_successful": analysis_successful,
+                "summary_path": str(summary_path),
+                "docker_log_path": str(docker_log_path),
+                "previous_result": non_empty_str(summary.get("result")),
+                "previous_error": non_empty_str(summary.get("error")),
+            }
+        )
+    return results
+
+
+def apply_recovery(summary_path: Path, sonar_task_id: str) -> None:
+    summary = dict(load_json(summary_path))
+    summary["result"] = "submission_success"
+    summary["submission_success"] = True
+    summary["sonar_task_id"] = sonar_task_id
+    summary["error"] = None
+    summary["recovered_from_docker_log"] = True
+    summary["recovered_at"] = timestamp_utc()
+    write_json(summary_path, summary)
+
+
+def extract_task_id(log_text: str) -> str | None:
+    matches = TASK_ID_RE.findall(log_text)
+    return matches[-1] if matches else None
+
+
+def load_json(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f"Expected JSON object: {path}")
+    return payload
+
+
+def read_text(path: Path) -> str:
+    if not path.is_file():
+        return ""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resubmit_missing_sonar.py
+++ b/scripts/resubmit_missing_sonar.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+SCRIPT_ROOT = Path(__file__).resolve().parent
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+if str(SCRIPT_ROOT) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_ROOT))
+
+from heimdall.images import DockerError, run_container  # noqa: E402
+from heimdall.manifests.queue import load_worker_config  # noqa: E402
+from heimdall.models import (  # noqa: E402
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+    STEP_LIDSKJALV_ORIGINAL,
+)
+from heimdall.utils import timestamp_utc  # noqa: E402
+
+import retry_lidskjalv_current_batch as lidskjalv_retry  # noqa: E402
+
+
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+DEFAULT_WORKER_CONFIG = Path("/srv/pipeline/worker.yaml")
+DEFAULT_OUTPUT_ROOT = Path("/srv/pipeline/retries/sonar-resubmission")
+DEFAULT_EXPECTED_COUNT = 45
+DEFAULT_MANUAL_SCANNER_IMAGE = "sonarsource/sonar-scanner-cli:latest"
+LIDSKJALV_STEPS = (
+    STEP_LIDSKJALV_ORIGINAL,
+    STEP_LIDSKJALV_GENERATED,
+    STEP_LIDSKJALV_GENERATED_V2,
+    STEP_LIDSKJALV_GENERATED_V3,
+)
+
+CODEX_RUN_IDS = (
+    "20260505T122153Z__ulisesbocchio_jasypt-spring-boot__2243cb80",
+    "20260505T150455Z__mbechler_marshalsec__243c5aa8",
+    "20260505T150537Z__frohoff_ysoserial__218bcffc",
+    "20260505T150549Z__xtuhcy_gecco__e1f32e1c",
+    "20260506T082045Z__happyfish100_fastdfs-client-java__4e7b6b34",
+    "20260506T082105Z__JakeWharton_RxRelay__9540ecc7",
+    "20260506T082129Z__amitshekhariitbhu_Android-Debug-Database__bf149df6",
+    "20260506T082136Z__amitshekhariitbhu_PRDownloader__611b12c8",
+    "20260506T083333Z__esoxjem_MovieGuide__dc1f20fb",
+    "20260507T093402Z__19MisterX98_SeedcrackerX__8e18d20d",
+    "20260507T093422Z__airbnb_native-navigation__9cf50bf9",
+    "20260507T093651Z__awaitility_awaitility__4fc23ccb",
+    "20260507T093656Z__DantSu_ESCPOS-ThermalPrinter-Android__f61030e4",
+    "20260507T093701Z__elvishew_xLog__3faa6b27",
+    "20260507T093708Z__EsotericSoftware_reflectasm__e34c5e8b",
+    "20260507T093714Z__evant_binding-collection-adapter__ac7972e1",
+    "20260507T093719Z__gothinkster_spring-boot-realworld-example-app__ee17e31a",
+    "20260507T093724Z__Grt1228_chatgpt-java__ae761b89",
+    "20260507T093731Z__j-easy_easy-rules__d4450831",
+    "20260508T095107Z__jOOQ_jOOR__23e17cf3",
+    "20260508T095113Z__LianjiaTech_retrofit-spring-boot-starter__24cb9eda",
+    "20260508T095119Z__linkedin_kafka-monitor__043db641",
+    "20260508T095125Z__macrozheng_mall-tiny__a81ec474",
+    "20260508T095131Z__Meituan-Dianping_walle__f78edcf1",
+    "20260508T095136Z__Mojang_brigadier__b5419b18",
+    "20260508T095142Z__monkeyWie_proxyee__c2c5bb4c",
+    "20260508T095147Z__mouzt_mzt-biz-log__8d3a0271",
+    "20260508T095153Z__Netflix_concurrency-limits__e8df64d8",
+    "20260508T095158Z__pwittchen_ReactiveNetwork__ddfde340",
+    "20260508T095204Z__RikkaApps_Shizuku-API__a27f6e41",
+    "20260508T095210Z__TheoKanning_openai-java__26909660",
+    "20260508T095214Z__whwlsfb_JDumpSpider__24fe3186",
+    "20260508T095219Z__YeautyYE_netty-websocket-spring-boot-starter__eb4d0a6b",
+    "20260508T095225Z__JMCuixy_swagger2word__0da57120",
+    "20260508T095230Z__eugene-khyst_postgresql-event-sourcing__90faafbb",
+    "20260508T095237Z__facebook_SoLoader__d3d721fb",
+    "20260508T095244Z__feiniaojin_graceful-response__cf1cd118",
+    "20260508T095249Z__jenkinsci_jenkinsfile-runner__9be9c0fb",
+    "20260508T095255Z__mitre_HTTP-Proxy-Servlet__c799c5e1",
+    "20260508T095300Z__stealthcopter_AndroidNetworkTools__a82af8a5",
+)
+
+CLAUDE_RUN_IDS = (
+    "20260510T103653Z__19MisterX98_SeedcrackerX__8e18d20d",
+    "20260510T154735Z__airbnb_native-navigation__9cf50bf9",
+    "20260510T154742Z__amitshekhariitbhu_Android-Debug-Database__bf149df6",
+    "20260510T154753Z__amitshekhariitbhu_PRDownloader__611b12c8",
+    "20260510T154759Z__awaitility_awaitility__4fc23ccb",
+    "20260510T154807Z__DantSu_ESCPOS-ThermalPrinter-Android__f61030e4",
+    "20260510T154813Z__elvishew_xLog__3faa6b27",
+    "20260510T154820Z__EsotericSoftware_reflectasm__e34c5e8b",
+    "20260510T154826Z__esoxjem_MovieGuide__dc1f20fb",
+    "20260510T154832Z__evant_binding-collection-adapter__ac7972e1",
+    "20260510T154845Z__frohoff_ysoserial__218bcffc",
+    "20260511T105128Z__gothinkster_spring-boot-realworld-example-app__ee17e31a",
+    "20260511T105134Z__Grt1228_chatgpt-java__ae761b89",
+    "20260511T105140Z__happyfish100_fastdfs-client-java__4e7b6b34",
+    "20260511T105145Z__j-easy_easy-rules__d4450831",
+    "20260511T105150Z__JakeWharton_RxRelay__9540ecc7",
+    "20260511T105155Z__jOOQ_jOOR__23e17cf3",
+    "20260511T105200Z__LianjiaTech_retrofit-spring-boot-starter__24cb9eda",
+    "20260511T105205Z__linkedin_kafka-monitor__043db641",
+    "20260511T105211Z__macrozheng_mall-tiny__a81ec474",
+    "20260511T105217Z__mbechler_marshalsec__243c5aa8",
+    "20260513T080244Z__Meituan-Dianping_walle__f78edcf1",
+    "20260513T080251Z__Mojang_brigadier__b5419b18",
+    "20260513T080257Z__monkeyWie_proxyee__c2c5bb4c",
+    "20260513T080303Z__mouzt_mzt-biz-log__8d3a0271",
+    "20260513T080309Z__Netflix_concurrency-limits__e8df64d8",
+    "20260513T080314Z__pwittchen_ReactiveNetwork__ddfde340",
+    "20260513T080320Z__RikkaApps_Shizuku-API__a27f6e41",
+    "20260513T080328Z__TheoKanning_openai-java__26909660",
+    "20260513T080335Z__ulisesbocchio_jasypt-spring-boot__2243cb80",
+    "20260513T080342Z__whwlsfb_JDumpSpider__24fe3186",
+    "20260514T193759Z__xtuhcy_gecco__e1f32e1c",
+    "20260514T193807Z__YeautyYE_netty-websocket-spring-boot-starter__eb4d0a6b",
+    "20260515T132132Z__JMCuixy_swagger2word__0da57120",
+    "20260515T132141Z__eugene-khyst_postgresql-event-sourcing__90faafbb",
+    "20260515T132149Z__facebook_SoLoader__d3d721fb",
+    "20260515T132155Z__feiniaojin_graceful-response__cf1cd118",
+    "20260515T132202Z__jenkinsci_jenkinsfile-runner__9be9c0fb",
+    "20260515T132208Z__mitre_HTTP-Proxy-Servlet__c799c5e1",
+    "20260518T082419Z__stealthcopter_AndroidNetworkTools__a82af8a5",
+)
+
+
+@dataclass(frozen=True)
+class MissingSonarTarget:
+    agent: str
+    run_id: str
+    step: str
+    scan_label: str
+    variant: str
+    follow_up_status: str | None
+    follow_up_reason: str | None
+    project_key: str
+    project_name: str | None
+    run_root: Path
+    manifest_path: Path
+    input_repo: Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Resubmit missing SonarCloud scans for the current Codex/Claude "
+            "experiment batch using sidecar-only logs."
+        )
+    )
+    parser.add_argument("--runs-root", type=Path, default=DEFAULT_RUNS_ROOT)
+    parser.add_argument("--worker-config", type=Path, default=DEFAULT_WORKER_CONFIG)
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument(
+        "--run-id",
+        action="append",
+        dest="run_ids",
+        help="Limit processing to one run id. Repeatable.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        choices=LIDSKJALV_STEPS,
+        dest="steps",
+        help="Limit processing to one Lidskjalv step. Repeatable.",
+    )
+    parser.add_argument(
+        "--expected-count",
+        type=int,
+        default=DEFAULT_EXPECTED_COUNT,
+        help="Expected target count for the unfiltered current batch.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--manual-fallback",
+        action="store_true",
+        help="Run manual sonar-scanner fallback after a failed Lidskjalv replay.",
+    )
+    parser.add_argument(
+        "--manual-only",
+        action="store_true",
+        help="Skip Lidskjalv replay and only run manual sonar-scanner fallback.",
+    )
+    parser.add_argument(
+        "--manual-scanner-image",
+        default=DEFAULT_MANUAL_SCANNER_IMAGE,
+        help=f"Sonar scanner image for manual fallback (default: {DEFAULT_MANUAL_SCANNER_IMAGE})",
+    )
+    parser.add_argument(
+        "--manual-timeout-sec",
+        type=float,
+        default=3600.0,
+        help="Timeout for each manual scanner fallback attempt.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    targets = discover_targets(
+        runs_root=args.runs_root,
+        run_ids=tuple(args.run_ids or ()),
+        steps=tuple(args.steps or LIDSKJALV_STEPS),
+    )
+    write_targets_manifest(args.output_root, targets)
+    validate_expected_count(
+        targets,
+        expected_count=args.expected_count,
+        filtered=bool(args.run_ids or args.steps),
+    )
+
+    if args.dry_run:
+        for target in targets:
+            print(format_target_line(target))
+        print(f"Selected {len(targets)} missing Sonar submission target(s).")
+        return 0
+
+    require_sonar_env(manual_only=args.manual_only)
+    worker_lidskjalv_image = current_lidskjalv_image(args.worker_config)
+    entries: list[dict[str, object]] = []
+    overall_success = True
+
+    for target in targets:
+        entry = process_target(
+            target,
+            output_root=args.output_root,
+            worker_lidskjalv_image=worker_lidskjalv_image,
+            force=args.force,
+            manual_fallback=args.manual_fallback,
+            manual_only=args.manual_only,
+            manual_scanner_image=args.manual_scanner_image,
+            manual_timeout_sec=args.manual_timeout_sec,
+        )
+        entries.append(entry)
+        if entry.get("submission_success") is not True:
+            overall_success = False
+
+    write_invocation_summary(args.output_root, entries)
+    write_residual_failures(args.output_root)
+    return 0 if overall_success else 1
+
+
+def discover_targets(
+    *,
+    runs_root: Path,
+    run_ids: tuple[str, ...] = (),
+    steps: tuple[str, ...] = LIDSKJALV_STEPS,
+) -> list[MissingSonarTarget]:
+    selected_run_ids = set(run_ids)
+    selected_steps = set(steps)
+    results: list[MissingSonarTarget] = []
+    for agent, run_id in scoped_run_ids():
+        if selected_run_ids and run_id not in selected_run_ids:
+            continue
+        run_root = runs_root / run_id
+        if not run_root.is_dir():
+            continue
+        follow_up_path = run_root / "pipeline" / "outputs" / "sonar_follow_up.json"
+        follow_up = load_json(follow_up_path)
+        entries = mapping(follow_up.get("steps"))
+        for step in LIDSKJALV_STEPS:
+            if step not in selected_steps:
+                continue
+            entry = mapping(entries.get(step))
+            if non_empty_str(entry.get("sonar_task_id")) is not None:
+                continue
+            target = build_target(agent, run_root, step, entry)
+            if target is not None:
+                results.append(target)
+    return results
+
+
+def build_target(
+    agent: str,
+    run_root: Path,
+    step: str,
+    follow_up_entry: Mapping[str, object],
+) -> MissingSonarTarget | None:
+    manifest_path = run_root / "services" / step / "config" / "manifest.yaml"
+    if not manifest_path.is_file():
+        return None
+    manifest = lidskjalv_retry.load_yaml_file(manifest_path)
+    project_key = non_empty_str(manifest.get("project_key"))
+    if project_key is None:
+        return None
+    input_repo = lidskjalv_retry.determine_input_repo(run_root, step)
+    if not input_repo.exists():
+        return None
+    scan_label = (
+        non_empty_str(manifest.get("scan_label"))
+        or non_empty_str(follow_up_entry.get("scan_label"))
+        or scan_label_for_step(step)
+    )
+    return MissingSonarTarget(
+        agent=agent,
+        run_id=run_root.name,
+        step=step,
+        scan_label=scan_label,
+        variant=variant_for_step(step),
+        follow_up_status=non_empty_str(follow_up_entry.get("status")),
+        follow_up_reason=non_empty_str(follow_up_entry.get("reason")),
+        project_key=project_key,
+        project_name=non_empty_str(manifest.get("project_name")),
+        run_root=run_root,
+        manifest_path=manifest_path,
+        input_repo=input_repo,
+    )
+
+
+def process_target(
+    target: MissingSonarTarget,
+    *,
+    output_root: Path,
+    worker_lidskjalv_image: str,
+    force: bool,
+    manual_fallback: bool,
+    manual_only: bool,
+    manual_scanner_image: str,
+    manual_timeout_sec: float | None,
+) -> dict[str, object]:
+    stable_dir = stable_step_output_dir(output_root, target)
+    prior_success = load_prior_success(stable_dir)
+    if prior_success is not None and not force:
+        print(f"skipped_prior_success: {target.run_id} {target.step}")
+        return {
+            **target_summary_fields(target),
+            "result": "skipped_prior_success",
+            "submission_success": True,
+            "stable_output_dir": str(stable_dir),
+            "attempt_dir": prior_success.get("attempt_dir"),
+            "sonar_task_id": prior_success.get("sonar_task_id"),
+        }
+
+    last_entry: dict[str, object] | None = None
+    if not manual_only:
+        last_entry = run_lidskjalv_attempt(
+            target,
+            output_root=output_root,
+            worker_lidskjalv_image=worker_lidskjalv_image,
+        )
+        if last_entry.get("submission_success") is True:
+            return last_entry
+
+    if manual_fallback or manual_only:
+        return run_manual_attempt(
+            target,
+            output_root=output_root,
+            scanner_image=manual_scanner_image,
+            timeout_sec=manual_timeout_sec,
+            prior_result=last_entry,
+        )
+
+    assert last_entry is not None
+    return last_entry
+
+
+def run_lidskjalv_attempt(
+    target: MissingSonarTarget,
+    *,
+    output_root: Path,
+    worker_lidskjalv_image: str,
+) -> dict[str, object]:
+    stable_dir = stable_step_output_dir(output_root, target)
+    attempt_dir = stable_dir / f"lidskjalv-attempt-{timestamp_slug()}"
+    selection = lidskjalv_retry.StepSelection(
+        run_id=target.run_id,
+        step=target.step,
+        source="sonar_follow_up_missing",
+        status=target.follow_up_status or "missing-sonar-task-id",
+        reason=target.follow_up_reason,
+        project_key=target.project_key,
+        run_root=target.run_root,
+    )
+    try:
+        context = lidskjalv_retry.build_replay_context(selection)
+        context = replace(
+            context,
+            requested_image_ref=worker_lidskjalv_image,
+            requested_image_source="worker_config_current",
+            configured_image_ref=worker_lidskjalv_image,
+        )
+        summary = dict(
+            lidskjalv_retry.execute_replay_attempt(
+                attempt_dir=attempt_dir,
+                context=context,
+                output_root=output_root,
+            )
+        )
+    except Exception as exc:  # pragma: no cover - operational failure capture
+        summary = {
+            **target_summary_fields(target),
+            "result": "lidskjalv_preflight_failed",
+            "submission_success": False,
+            "stable_output_dir": str(stable_dir),
+            "attempt_dir": str(attempt_dir),
+            "error": str(exc) or exc.__class__.__name__,
+            "finished_at": timestamp_utc(),
+        }
+        ensure_directory(attempt_dir)
+
+    summary.update(
+        {
+            "attempt_type": "lidskjalv",
+            "agent": target.agent,
+            "variant": target.variant,
+            "scan_label": target.scan_label,
+        }
+    )
+    write_json(attempt_dir / "summary.json", summary)
+    return summary
+
+
+def run_manual_attempt(
+    target: MissingSonarTarget,
+    *,
+    output_root: Path,
+    scanner_image: str,
+    timeout_sec: float | None,
+    prior_result: Mapping[str, object] | None,
+) -> dict[str, object]:
+    stable_dir = stable_step_output_dir(output_root, target)
+    attempt_dir = stable_dir / f"manual-attempt-{timestamp_slug()}"
+    workspace = attempt_dir / "workspace"
+    docker_log_path = attempt_dir / "docker.log"
+    ensure_directory(attempt_dir)
+    if workspace.exists():
+        shutil.rmtree(workspace)
+    shutil.copytree(target.input_repo, workspace, symlinks=True)
+
+    report_task_path = workspace / ".scannerwork" / "report-task.txt"
+    result = "manual_submission_failed"
+    sonar_task_id: str | None = None
+    error: str | None = None
+    visibility_preflight: dict[str, object] | None = None
+    try:
+        visibility_preflight = ensure_public_sonar_project(target)
+        run_container(
+            scanner_image,
+            {
+                "SONAR_HOST_URL": os.environ["SONAR_HOST_URL"],
+                "SONAR_TOKEN": os.environ["SONAR_TOKEN"],
+            },
+            [(workspace, "/usr/src", False)],
+            output_path=docker_log_path,
+            timeout_sec=timeout_sec,
+            timeout_reason="manual-sonar-timeout",
+            command_args=manual_scanner_args(target),
+        )
+        task = parse_report_task(report_task_path)
+        sonar_task_id = non_empty_str(task.get("ceTaskId"))
+        reported_key = non_empty_str(task.get("projectKey"))
+        if sonar_task_id is not None and reported_key in {None, target.project_key}:
+            result = "submission_success"
+        else:
+            error = "manual scanner did not emit a matching ceTaskId/projectKey"
+    except Exception as exc:  # pragma: no cover - operational failure capture
+        error = str(exc) or exc.__class__.__name__
+
+    summary: dict[str, object] = {
+        **target_summary_fields(target),
+        "attempt_type": "manual",
+        "result": result,
+        "submission_success": result == "submission_success",
+        "stable_output_dir": str(stable_dir),
+        "attempt_dir": str(attempt_dir),
+        "input_repo": str(target.input_repo),
+        "workspace": str(workspace),
+        "scanner_image": scanner_image,
+        "docker_log_path": str(docker_log_path),
+        "report_task_path": str(report_task_path),
+        "sonar_task_id": sonar_task_id,
+        "visibility_preflight": visibility_preflight,
+        "prior_result": dict(prior_result) if prior_result is not None else None,
+        "error": error,
+        "finished_at": timestamp_utc(),
+    }
+    write_json(attempt_dir / "summary.json", summary)
+    print(f"{result}: {target.run_id} {target.step} project_key={target.project_key}")
+    return summary
+
+
+def ensure_public_sonar_project(target: MissingSonarTarget) -> dict[str, object]:
+    organization = os.environ.get("SONAR_ORGANIZATION")
+    if not organization:
+        return {"status": "skipped", "reason": "missing-sonar-organization"}
+    project_key = target.project_key
+    project_name = target.project_name or project_key
+    show = sonar_api_request("GET", "/api/components/show", {"component": project_key})
+    if show["ok"] is True:
+        visibility = non_empty_str(mapping(show.get("json")).get("visibility"))
+        update = sonar_api_request(
+            "POST",
+            "/api/projects/update_visibility",
+            {"project": project_key, "visibility": "public"},
+        )
+        return {
+            "status": "updated_existing" if update["ok"] else "update_failed",
+            "previous_visibility": visibility,
+            "update": update,
+        }
+    create = sonar_api_request(
+        "POST",
+        "/api/projects/create",
+        {
+            "organization": organization,
+            "project": project_key,
+            "name": project_name,
+            "visibility": "public",
+        },
+    )
+    if create["ok"] is True:
+        return {"status": "created_public", "create": create}
+    if str(create.get("http_status")) == "400":
+        update = sonar_api_request(
+            "POST",
+            "/api/projects/update_visibility",
+            {"project": project_key, "visibility": "public"},
+        )
+        return {
+            "status": "updated_after_create_conflict"
+            if update["ok"]
+            else "update_failed",
+            "create": create,
+            "update": update,
+        }
+    return {"status": "create_failed", "create": create}
+
+
+def sonar_api_request(
+    method: str, path: str, params: Mapping[str, str]
+) -> dict[str, object]:
+    host_url = os.environ["SONAR_HOST_URL"].rstrip("/")
+    token = os.environ["SONAR_TOKEN"]
+    encoded = urllib.parse.urlencode(params).encode("utf-8")
+    url = f"{host_url}{path}"
+    data = encoded if method == "POST" else None
+    if method == "GET":
+        url = f"{url}?{encoded.decode('utf-8')}"
+    auth = base64.b64encode(f"{token}:".encode("utf-8")).decode("ascii")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={
+            "Authorization": f"Basic {auth}",
+            "Accept": "application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8", errors="replace")
+            return {
+                "ok": True,
+                "http_status": response.status,
+                "json": parse_optional_json(body),
+            }
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        return {
+            "ok": False,
+            "http_status": exc.code,
+            "error": detail.strip() or exc.reason,
+        }
+    except OSError as exc:
+        return {"ok": False, "http_status": None, "error": str(exc)}
+
+
+def parse_optional_json(text: str) -> object:
+    stripped = text.strip()
+    if not stripped:
+        return {}
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        return {"raw": stripped}
+
+
+def manual_scanner_args(target: MissingSonarTarget) -> list[str]:
+    args = [
+        f"-Dsonar.projectKey={target.project_key}",
+        f"-Dsonar.projectName={target.project_name or target.project_key}",
+        "-Dsonar.sources=.",
+        "-Dsonar.scm.disabled=true",
+        "-Dsonar.java.binaries=.",
+        "-Dsonar.working.directory=/usr/src/.scannerwork",
+        "-Dsonar.scanner.metadataFilePath=/usr/src/.scannerwork/report-task.txt",
+    ]
+    organization = os.environ.get("SONAR_ORGANIZATION")
+    if organization:
+        args.append(f"-Dsonar.organization={organization}")
+    return args
+
+
+def parse_report_task(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    result: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.lstrip().startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
+def load_prior_success(stable_dir: Path) -> Mapping[str, object] | None:
+    if not stable_dir.is_dir():
+        return None
+    for summary_path in sorted(
+        stable_dir.glob("*attempt-*/summary.json"), reverse=True
+    ):
+        summary = load_optional_json(summary_path)
+        if summary.get("submission_success") is True and non_empty_str(
+            summary.get("sonar_task_id")
+        ):
+            return summary
+    return None
+
+
+def write_targets_manifest(
+    output_root: Path, targets: Sequence[MissingSonarTarget]
+) -> None:
+    write_json(
+        output_root / "targets.json",
+        {
+            "schema_version": "heimdall_sonar_resubmission_targets.v1",
+            "generated_at": timestamp_utc(),
+            "target_count": len(targets),
+            "targets": [target_summary_fields(target) for target in targets],
+        },
+    )
+
+
+def write_invocation_summary(
+    output_root: Path, entries: Sequence[Mapping[str, object]]
+) -> None:
+    write_json(
+        output_root / f"invocation-{timestamp_slug()}.json",
+        {
+            "schema_version": "heimdall_sonar_resubmission_invocation.v1",
+            "finished_at": timestamp_utc(),
+            "entries": list(entries),
+        },
+    )
+
+
+def write_residual_failures(output_root: Path) -> None:
+    failures: list[Mapping[str, object]] = []
+    for summary_path in sorted(output_root.glob("*/*/*attempt-*/summary.json")):
+        summary = load_optional_json(summary_path)
+        if summary.get("submission_success") is True:
+            continue
+        failures.append(summary)
+    write_json(
+        output_root / "residual_failures.json",
+        {
+            "schema_version": "heimdall_sonar_resubmission_residual_failures.v1",
+            "generated_at": timestamp_utc(),
+            "failure_count": len(failures),
+            "failures": failures,
+        },
+    )
+
+
+def validate_expected_count(
+    targets: Sequence[MissingSonarTarget], *, expected_count: int, filtered: bool
+) -> None:
+    if filtered:
+        return
+    if len(targets) != expected_count:
+        raise RuntimeError(
+            f"Expected {expected_count} missing Sonar target(s), found {len(targets)}"
+        )
+
+
+def current_lidskjalv_image(worker_config_path: Path) -> str:
+    config = load_worker_config(worker_config_path)
+    image_ref = config.images.lidskjalv.strip()
+    if not image_ref:
+        raise RuntimeError(
+            f"Worker config does not define images.lidskjalv: {worker_config_path}"
+        )
+    return image_ref
+
+
+def require_sonar_env(*, manual_only: bool) -> None:
+    required = ["SONAR_HOST_URL", "SONAR_TOKEN", "SONAR_ORGANIZATION"]
+    if manual_only:
+        required = ["SONAR_HOST_URL", "SONAR_TOKEN"]
+    missing = [name for name in required if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required Sonar environment variable(s): {', '.join(missing)}"
+        )
+
+
+def scoped_run_ids() -> list[tuple[str, str]]:
+    return [
+        *(("codex", run_id) for run_id in CODEX_RUN_IDS),
+        *(("claude", run_id) for run_id in CLAUDE_RUN_IDS),
+    ]
+
+
+def stable_step_output_dir(output_root: Path, target: MissingSonarTarget) -> Path:
+    return output_root / target.run_id / target.step
+
+
+def target_summary_fields(target: MissingSonarTarget) -> dict[str, object]:
+    return {
+        "agent": target.agent,
+        "run_id": target.run_id,
+        "step": target.step,
+        "scan_label": target.scan_label,
+        "variant": target.variant,
+        "follow_up_status": target.follow_up_status,
+        "follow_up_reason": target.follow_up_reason,
+        "project_key": target.project_key,
+        "project_name": target.project_name,
+        "manifest_path": str(target.manifest_path),
+        "input_repo": str(target.input_repo),
+    }
+
+
+def format_target_line(target: MissingSonarTarget) -> str:
+    return (
+        f"{target.agent}\t{target.run_id}\t{target.step}\t{target.variant}\t"
+        f"{target.follow_up_status or ''}\t{target.follow_up_reason or ''}\t"
+        f"{target.project_key}\t{target.input_repo}"
+    )
+
+
+def scan_label_for_step(step: str) -> str:
+    if step == STEP_LIDSKJALV_GENERATED:
+        return "generated"
+    if step == STEP_LIDSKJALV_GENERATED_V2:
+        return "generated-v2"
+    if step == STEP_LIDSKJALV_GENERATED_V3:
+        return "generated-v3"
+    return "original"
+
+
+def variant_for_step(step: str) -> str:
+    if step == STEP_LIDSKJALV_GENERATED:
+        return "generated"
+    if step == STEP_LIDSKJALV_GENERATED_V2:
+        return "v2"
+    if step == STEP_LIDSKJALV_GENERATED_V3:
+        return "v3"
+    return "original"
+
+
+def load_json(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f"Expected JSON object: {path}")
+    return payload
+
+
+def load_optional_json(path: Path) -> Mapping[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        return load_json(path)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    ensure_directory(path.parent)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def timestamp_slug() -> str:
+    return timestamp_utc().replace("-", "").replace(":", "").removesuffix("Z") + "Z"
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DockerError as exc:
+        print(f"Docker error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/retry_lidskjalv_current_batch.py
+++ b/scripts/retry_lidskjalv_current_batch.py
@@ -1,0 +1,725 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from heimdall.adapters import normalized_report_status  # noqa: E402
+from heimdall.images import DockerError, run_container  # noqa: E402
+from heimdall.manifests.pipeline import load_pipeline_manifest  # noqa: E402
+from heimdall.reporting import load_report  # noqa: E402
+from heimdall.simpleyaml import loads  # noqa: E402
+
+
+DEFAULT_BATCH_START = "20260430T100001Z__ulisesbocchio_jasypt-spring-boot__2243cb80"
+DEFAULT_BATCH_END = "20260508T095300Z__stealthcopter_AndroidNetworkTools__a82af8a5"
+DEFAULT_OUTPUT_ROOT = Path("/srv/pipeline/retries/lidskjalv-current-batch")
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+DEFAULT_WORKER_CONFIG = Path("/srv/pipeline/worker.yaml")
+LIDSKJALV_STEPS = (
+    "lidskjalv-original",
+    "lidskjalv-generated",
+    "lidskjalv-generated-v2",
+    "lidskjalv-generated-v3",
+)
+SERVICE_REPORT_SUCCESS = "passed"
+TARGET_FAILURE_STATUSES = frozenset({"failed", "error"})
+REQUIRED_SONAR_ENV_VARS = ("SONAR_HOST_URL", "SONAR_TOKEN", "SONAR_ORGANIZATION")
+
+
+@dataclass(frozen=True)
+class StepSelection:
+    run_id: str
+    step: str
+    source: str
+    status: str
+    reason: str | None
+    project_key: str | None
+    run_root: Path
+
+
+@dataclass(frozen=True)
+class ReplayContext:
+    selection: StepSelection
+    input_repo: Path
+    manifest_payload: Mapping[str, object]
+    manifest_text: str
+    project_key: str
+    requested_image_ref: str
+    requested_image_source: str
+    configured_image_ref: str | None
+    timeout_sec: float | None
+    service_root: Path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay failed Lidskjalv submissions for the current experiment batch."
+    )
+    parser.add_argument(
+        "--runs-root",
+        type=Path,
+        default=DEFAULT_RUNS_ROOT,
+        help=f"Pipeline runs root (default: {DEFAULT_RUNS_ROOT})",
+    )
+    parser.add_argument(
+        "--worker-config",
+        type=Path,
+        default=DEFAULT_WORKER_CONFIG,
+        help=f"Worker config used to discover the default runs root (default: {DEFAULT_WORKER_CONFIG})",
+    )
+    parser.add_argument(
+        "--batch-start",
+        default=DEFAULT_BATCH_START,
+        help=f"First run_id to include (default: {DEFAULT_BATCH_START})",
+    )
+    parser.add_argument(
+        "--batch-end",
+        default=DEFAULT_BATCH_END,
+        help=f"Last run_id to include (default: {DEFAULT_BATCH_END})",
+    )
+    parser.add_argument(
+        "--run-id",
+        action="append",
+        dest="run_ids",
+        help="Limit retries to a specific run_id. Repeatable.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        choices=LIDSKJALV_STEPS,
+        dest="steps",
+        help="Limit retries to a specific lidskjalv step. Repeatable.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help=f"Stable root for standalone replay outputs (default: {DEFAULT_OUTPUT_ROOT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List selected retry targets and planned output paths without running Docker.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replay even if a prior standalone retry already submitted successfully.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    runs_root = resolve_runs_root(args.runs_root, args.worker_config)
+    selections = discover_targets(
+        runs_root=runs_root,
+        batch_start=args.batch_start,
+        batch_end=args.batch_end,
+        run_ids=tuple(args.run_ids or ()),
+        steps=tuple(args.steps or LIDSKJALV_STEPS),
+    )
+    invocation_started_at = timestamp_slug()
+    aggregate_entries: list[dict[str, object]] = []
+
+    if not selections:
+        print("No failed/error lidskjalv targets matched the requested scope.")
+        write_invocation_summary(
+            args.output_root,
+            invocation_started_at,
+            runs_root,
+            aggregate_entries,
+        )
+        return 0
+
+    if args.dry_run:
+        for selection in selections:
+            stable_dir = stable_step_output_dir(args.output_root, selection)
+            print(
+                f"{selection.run_id}\t{selection.step}\t{selection.status}\t"
+                f"{selection.reason or ''}\t{stable_dir}"
+            )
+            aggregate_entries.append(
+                {
+                    "run_id": selection.run_id,
+                    "step": selection.step,
+                    "selector_source": selection.source,
+                    "selected_status": selection.status,
+                    "selected_reason": selection.reason,
+                    "result": "dry-run",
+                    "stable_output_dir": str(stable_dir),
+                }
+            )
+        write_invocation_summary(
+            args.output_root,
+            invocation_started_at,
+            runs_root,
+            aggregate_entries,
+        )
+        return 0
+
+    require_sonar_env()
+    overall_success = True
+
+    for selection in selections:
+        stable_dir = stable_step_output_dir(args.output_root, selection)
+        prior_success = load_prior_success(stable_dir)
+        if prior_success is not None and not args.force:
+            print(
+                f"Skipping {selection.run_id} {selection.step}: prior submission success "
+                f"at {prior_success['attempt_dir']}"
+            )
+            aggregate_entries.append(
+                {
+                    "run_id": selection.run_id,
+                    "step": selection.step,
+                    "selector_source": selection.source,
+                    "selected_status": selection.status,
+                    "selected_reason": selection.reason,
+                    "result": "skipped_prior_success",
+                    "stable_output_dir": str(stable_dir),
+                    "attempt_dir": prior_success["attempt_dir"],
+                }
+            )
+            continue
+
+        attempt_dir = stable_dir / f"attempt-{timestamp_slug()}"
+        try:
+            context = build_replay_context(selection)
+            attempt_entry = execute_replay_attempt(
+                attempt_dir=attempt_dir,
+                context=context,
+                output_root=args.output_root,
+            )
+        except Exception as exc:  # pragma: no cover - failure capture
+            overall_success = False
+            error_entry = {
+                "run_id": selection.run_id,
+                "step": selection.step,
+                "selector_source": selection.source,
+                "selected_status": selection.status,
+                "selected_reason": selection.reason,
+                "result": "preflight_failed",
+                "stable_output_dir": str(stable_dir),
+                "attempt_dir": str(attempt_dir),
+                "error": str(exc) or exc.__class__.__name__,
+            }
+            ensure_directory(attempt_dir)
+            write_json(attempt_dir / "summary.json", error_entry)
+            print(
+                f"Replay preflight failed for {selection.run_id} {selection.step}: "
+                f"{error_entry['error']}",
+                file=sys.stderr,
+            )
+            aggregate_entries.append(error_entry)
+            continue
+
+        aggregate_entries.append(attempt_entry)
+        if attempt_entry["result"] != "submission_success":
+            overall_success = False
+
+    write_invocation_summary(
+        args.output_root,
+        invocation_started_at,
+        runs_root,
+        aggregate_entries,
+    )
+    return 0 if overall_success else 1
+
+
+def resolve_runs_root(explicit_runs_root: Path, worker_config: Path) -> Path:
+    if explicit_runs_root != DEFAULT_RUNS_ROOT:
+        return explicit_runs_root.resolve()
+    if not worker_config.is_file():
+        return explicit_runs_root.resolve()
+    payload = load_yaml_file(worker_config)
+    runs_root = payload.get("runs_root")
+    if isinstance(runs_root, str) and runs_root.strip():
+        return Path(runs_root).resolve()
+    return explicit_runs_root.resolve()
+
+
+def discover_targets(
+    *,
+    runs_root: Path,
+    batch_start: str,
+    batch_end: str,
+    run_ids: tuple[str, ...],
+    steps: tuple[str, ...],
+) -> list[StepSelection]:
+    selected_run_ids = set(run_ids)
+    results: list[StepSelection] = []
+    for run_root in sorted(path for path in runs_root.iterdir() if path.is_dir()):
+        run_id = run_root.name
+        if selected_run_ids:
+            if run_id not in selected_run_ids:
+                continue
+        elif run_id < batch_start or run_id > batch_end:
+            continue
+        pipeline_report = load_optional_json(
+            run_root / "pipeline" / "outputs" / "run_report.json"
+        )
+        for step in steps:
+            selection = select_step_target(run_root, step, pipeline_report)
+            if selection is not None:
+                results.append(selection)
+    return results
+
+
+def select_step_target(
+    run_root: Path,
+    step: str,
+    pipeline_report: Mapping[str, object] | None,
+) -> StepSelection | None:
+    service_report_path = (
+        run_root / "services" / step / "run" / "outputs" / "run_report.json"
+    )
+    if service_report_path.is_file():
+        service_report = load_json_file(service_report_path)
+        status = str(service_report.get("status") or "").strip()
+        if status in TARGET_FAILURE_STATUSES:
+            reason = optional_non_empty_str(service_report.get("reason"))
+            project_key = optional_non_empty_str(service_report.get("project_key"))
+            return StepSelection(
+                run_id=run_root.name,
+                step=step,
+                source="service_report",
+                status=status,
+                reason=reason,
+                project_key=project_key,
+                run_root=run_root,
+            )
+        return None
+
+    pipeline_step = pipeline_step_state(pipeline_report, step)
+    status = optional_non_empty_str(pipeline_step.get("status"))
+    if status not in TARGET_FAILURE_STATUSES:
+        return None
+    reason = optional_non_empty_str(pipeline_step.get("reason"))
+    project_key = read_manifest_project_key(
+        run_root / "services" / step / "config" / "manifest.yaml"
+    )
+    return StepSelection(
+        run_id=run_root.name,
+        step=step,
+        source="pipeline_report_fallback",
+        status=status,
+        reason=reason,
+        project_key=project_key,
+        run_root=run_root,
+    )
+
+
+def pipeline_step_state(
+    pipeline_report: Mapping[str, object] | None, step: str
+) -> Mapping[str, object]:
+    if pipeline_report is None:
+        return {}
+    steps = pipeline_report.get("steps")
+    if not isinstance(steps, Mapping):
+        return {}
+    entry = steps.get(step)
+    return entry if isinstance(entry, Mapping) else {}
+
+
+def build_replay_context(selection: StepSelection) -> ReplayContext:
+    service_root = selection.run_root / "services" / selection.step
+    manifest_path = service_root / "config" / "manifest.yaml"
+    if not manifest_path.is_file():
+        raise RuntimeError(f"Missing stored manifest: {manifest_path}")
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    manifest_payload = load_yaml_file(manifest_path)
+    project_key = optional_non_empty_str(manifest_payload.get("project_key"))
+    if project_key is None:
+        raise RuntimeError(f"Manifest is missing project_key: {manifest_path}")
+    input_repo = determine_input_repo(selection.run_root, selection.step)
+    if not input_repo.exists():
+        raise RuntimeError(
+            f"Resolved input repo does not exist for {selection.step}: {input_repo}"
+        )
+    requested_image_ref, requested_image_source, configured_image_ref = (
+        resolve_lidskjalv_image(selection.run_root, selection.step)
+    )
+    timeout_sec = load_lidskjalv_timeout(selection.run_root)
+    return ReplayContext(
+        selection=selection,
+        input_repo=input_repo,
+        manifest_payload=manifest_payload,
+        manifest_text=manifest_text,
+        project_key=project_key,
+        requested_image_ref=requested_image_ref,
+        requested_image_source=requested_image_source,
+        configured_image_ref=configured_image_ref,
+        timeout_sec=timeout_sec,
+        service_root=service_root,
+    )
+
+
+def determine_input_repo(run_root: Path, step: str) -> Path:
+    if step == "lidskjalv-original":
+        return run_root / "services" / "brokk" / "run" / "artifacts" / "original-repo"
+    suffix = step_suffix(step)
+    kvasir_service = "kvasir" if suffix == "" else f"kvasir-{suffix}"
+    andvari_service = "andvari" if suffix == "" else f"andvari-{suffix}"
+    ported_repo = (
+        run_root
+        / "services"
+        / kvasir_service
+        / "run"
+        / "artifacts"
+        / "ported-tests-repo"
+    )
+    if ported_repo.exists() and has_valid_kvasir_report(run_root, step):
+        return ported_repo
+    return (
+        run_root / "services" / andvari_service / "run" / "artifacts" / "generated-repo"
+    )
+
+
+def has_valid_kvasir_report(run_root: Path, step: str) -> bool:
+    report_path = kvasir_report_path(run_root, step)
+    if not report_path.is_file():
+        return False
+    try:
+        report = load_report(report_path)
+    except RuntimeError:
+        return False
+    if not isinstance(report, Mapping):
+        return False
+    return (
+        normalized_report_status(kvasir_step_for_lidskjalv_step(step), report)
+        is not None
+    )
+
+
+def kvasir_report_path(run_root: Path, step: str) -> Path:
+    kvasir_step = kvasir_step_for_lidskjalv_step(step)
+    service = "kvasir" if step_suffix(step) == "" else kvasir_step
+    return run_root / "services" / service / "run" / "outputs" / "test_port.json"
+
+
+def kvasir_step_for_lidskjalv_step(step: str) -> str:
+    suffix = step_suffix(step)
+    return "kvasir" if suffix == "" else f"kvasir-{suffix}"
+
+
+def step_suffix(step: str) -> str:
+    if step.endswith("-v2"):
+        return "v2"
+    if step.endswith("-v3"):
+        return "v3"
+    return ""
+
+
+def resolve_lidskjalv_image(run_root: Path, step: str) -> tuple[str, str, str | None]:
+    state_path = run_root / "pipeline" / "state.json"
+    state = load_json_file(state_path)
+    steps = state.get("steps")
+    if not isinstance(steps, Mapping):
+        raise RuntimeError(f"Invalid pipeline state: {state_path}")
+    step_state = steps.get(step)
+    if not isinstance(step_state, Mapping):
+        raise RuntimeError(f"Missing step state for {step}: {state_path}")
+    configured = optional_non_empty_str(step_state.get("configured_image_ref"))
+    resolved = optional_non_empty_str(step_state.get("resolved_image_id"))
+    if resolved is not None:
+        return resolved, "resolved_image_id", configured
+    if configured is not None:
+        return configured, "configured_image_ref", configured
+    raise RuntimeError(f"Missing image reference for {step}: {state_path}")
+
+
+def load_lidskjalv_timeout(run_root: Path) -> float | None:
+    manifest_path = run_root / "pipeline" / "manifest.yaml"
+    if not manifest_path.is_file():
+        return 7200.0
+    _manifest_text, config = load_pipeline_manifest(manifest_path)
+    timeout_sec = config.lidskjalv.execution_timeout_sec
+    if timeout_sec <= 0:
+        return None
+    return float(timeout_sec)
+
+
+def execute_replay_attempt(
+    attempt_dir: Path,
+    context: ReplayContext,
+    output_root: Path,
+) -> dict[str, object]:
+    ensure_directory(attempt_dir)
+    config_dir = attempt_dir / "config"
+    run_dir = attempt_dir / "run"
+    outputs_dir = run_dir / "outputs"
+    ensure_directory(config_dir, 0o755)
+    # Match Heimdall's step runtime staging so the service user can create outputs.
+    ensure_directory(run_dir, 0o777)
+    ensure_directory(outputs_dir, 0o777)
+
+    copied_manifest_path = config_dir / "manifest.yaml"
+    copied_manifest_path.write_text(context.manifest_text, encoding="utf-8")
+    docker_log_path = attempt_dir / "docker.log"
+
+    container_env = {
+        "LIDSKJALV_MANIFEST": "/run/config/manifest.yaml",
+        "SONAR_HOST_URL": os.environ["SONAR_HOST_URL"],
+        "SONAR_TOKEN": os.environ["SONAR_TOKEN"],
+        "SONAR_ORGANIZATION": os.environ["SONAR_ORGANIZATION"],
+    }
+    mounts = [
+        (context.input_repo, "/input/repo", True),
+        (config_dir, "/run/config", True),
+        (run_dir, "/run", False),
+    ]
+
+    image_ref_used, image_source_used = run_lidskjalv_container(
+        requested_image_ref=context.requested_image_ref,
+        requested_image_source=context.requested_image_source,
+        configured_image_ref=context.configured_image_ref,
+        env=container_env,
+        mounts=mounts,
+        log_path=docker_log_path,
+        timeout_sec=context.timeout_sec,
+    )
+
+    retry_report_path = run_dir / "outputs" / "run_report.json"
+    retry_report = load_optional_json(retry_report_path)
+    summary = summarize_attempt(
+        context=context,
+        attempt_dir=attempt_dir,
+        retry_report=retry_report,
+        image_ref_used=image_ref_used,
+        image_source_used=image_source_used,
+        docker_log_path=docker_log_path,
+        output_root=output_root,
+    )
+    write_json(attempt_dir / "summary.json", summary)
+    print(
+        f"{summary['result']}: {context.selection.run_id} {context.selection.step} "
+        f"project_key={context.project_key}"
+    )
+    return summary
+
+
+def run_lidskjalv_container(
+    *,
+    requested_image_ref: str,
+    requested_image_source: str,
+    configured_image_ref: str | None,
+    env: Mapping[str, str],
+    mounts: list[tuple[Path, str, bool]],
+    log_path: Path,
+    timeout_sec: float | None,
+) -> tuple[str, str]:
+    try:
+        run_container(
+            requested_image_ref,
+            dict(env),
+            mounts,
+            output_path=log_path,
+            timeout_sec=timeout_sec,
+            timeout_reason="lidskjalv-timeout",
+        )
+        return requested_image_ref, requested_image_source
+    except DockerError as exc:
+        if (
+            requested_image_source != "resolved_image_id"
+            or not looks_like_missing_image(exc)
+            or configured_image_ref is None
+            or configured_image_ref == requested_image_ref
+        ):
+            raise
+    run_container(
+        configured_image_ref,
+        dict(env),
+        mounts,
+        output_path=log_path,
+        timeout_sec=timeout_sec,
+        timeout_reason="lidskjalv-timeout",
+    )
+    return configured_image_ref, "configured_image_ref_fallback"
+
+
+def summarize_attempt(
+    *,
+    context: ReplayContext,
+    attempt_dir: Path,
+    retry_report: Mapping[str, object] | None,
+    image_ref_used: str,
+    image_source_used: str,
+    docker_log_path: Path,
+    output_root: Path,
+) -> dict[str, object]:
+    sonar_task_id = retry_scan_task_id(retry_report)
+    retry_project_key = (
+        optional_non_empty_str(retry_report.get("project_key"))
+        if retry_report is not None
+        else None
+    )
+    report_status = (
+        optional_non_empty_str(retry_report.get("status"))
+        if retry_report is not None
+        else None
+    )
+    submission_success = (
+        retry_report is not None
+        and report_status == SERVICE_REPORT_SUCCESS
+        and sonar_task_id is not None
+        and retry_project_key == context.project_key
+    )
+    result = "submission_success" if submission_success else "submission_failed"
+    return {
+        "run_id": context.selection.run_id,
+        "step": context.selection.step,
+        "selector_source": context.selection.source,
+        "selected_status": context.selection.status,
+        "selected_reason": context.selection.reason,
+        "result": result,
+        "submission_success": submission_success,
+        "attempt_dir": str(attempt_dir),
+        "stable_output_dir": str(
+            stable_step_output_dir(output_root, context.selection)
+        ),
+        "input_repo": str(context.input_repo),
+        "project_key": context.project_key,
+        "retry_project_key": retry_project_key,
+        "image_ref_requested": context.requested_image_ref,
+        "image_source_requested": context.requested_image_source,
+        "configured_image_ref": context.configured_image_ref,
+        "image_ref_used": image_ref_used,
+        "image_source_used": image_source_used,
+        "timeout_sec": context.timeout_sec,
+        "retry_report_path": str(attempt_dir / "run" / "outputs" / "run_report.json"),
+        "retry_report_status": report_status,
+        "retry_report_reason": (
+            optional_non_empty_str(retry_report.get("reason"))
+            if retry_report is not None
+            else None
+        ),
+        "sonar_task_id": sonar_task_id,
+        "docker_log_path": str(docker_log_path),
+        "finished_at": timestamp_iso(),
+    }
+
+
+def retry_scan_task_id(report: Mapping[str, object] | None) -> str | None:
+    if report is None:
+        return None
+    scan = report.get("scan")
+    if not isinstance(scan, Mapping):
+        return None
+    return optional_non_empty_str(scan.get("sonar_task_id"))
+
+
+def load_prior_success(stable_dir: Path) -> Mapping[str, object] | None:
+    if not stable_dir.is_dir():
+        return None
+    for summary_path in sorted(stable_dir.glob("attempt-*/summary.json"), reverse=True):
+        summary = load_optional_json(summary_path)
+        if not isinstance(summary, Mapping):
+            continue
+        if summary.get("submission_success") is True:
+            return summary
+    return None
+
+
+def stable_step_output_dir(output_root: Path, selection: StepSelection) -> Path:
+    return output_root / selection.run_id / selection.step
+
+
+def write_invocation_summary(
+    output_root: Path,
+    invocation_started_at: str,
+    runs_root: Path,
+    entries: Sequence[Mapping[str, object]],
+) -> None:
+    ensure_directory(output_root)
+    write_json(
+        output_root / f"invocation-{invocation_started_at}.json",
+        {
+            "invocation_started_at": invocation_started_at,
+            "runs_root": str(runs_root),
+            "entries": list(entries),
+        },
+    )
+
+
+def require_sonar_env() -> None:
+    missing = [name for name in REQUIRED_SONAR_ENV_VARS if not os.environ.get(name)]
+    if missing:
+        raise RuntimeError(
+            f"Missing required Sonar environment variable(s): {', '.join(missing)}"
+        )
+
+
+def read_manifest_project_key(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    payload = load_yaml_file(path)
+    return optional_non_empty_str(payload.get("project_key"))
+
+
+def load_yaml_file(path: Path) -> Mapping[str, object]:
+    loaded = loads(path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, Mapping):
+        raise RuntimeError(f"Expected mapping YAML document: {path}")
+    return loaded
+
+
+def load_json_file(path: Path) -> Mapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise RuntimeError(f"Expected JSON object: {path}")
+    return payload
+
+
+def load_optional_json(path: Path) -> Mapping[str, object] | None:
+    if not path.is_file():
+        return None
+    return load_json_file(path)
+
+
+def optional_non_empty_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def looks_like_missing_image(exc: Exception) -> bool:
+    detail = str(exc).lower()
+    return "no such image" in detail or "unable to find image" in detail
+
+
+def ensure_directory(path: Path, mode: int | None = None) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    if mode is not None:
+        path.chmod(mode)
+
+
+def write_json(path: Path, payload: Mapping[str, object]) -> None:
+    ensure_directory(path.parent)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def timestamp_slug() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def timestamp_iso() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/retry_lidskjalv_latest_run.py
+++ b/scripts/retry_lidskjalv_latest_run.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from dataclasses import replace
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from heimdall.manifests.queue import load_worker_config  # noqa: E402
+
+import retry_lidskjalv_current_batch as base  # noqa: E402
+
+
+DEFAULT_OUTPUT_ROOT = Path("/srv/pipeline/retries/lidskjalv-latest-run")
+DEFAULT_WORKER_CONFIG = Path("/srv/pipeline/worker.yaml")
+DEFAULT_RUNS_ROOT = Path("/srv/pipeline/runs")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Replay failed Lidskjalv submissions for the latest pipeline run."
+    )
+    parser.add_argument(
+        "--runs-root",
+        type=Path,
+        default=DEFAULT_RUNS_ROOT,
+        help=f"Pipeline runs root (default: {DEFAULT_RUNS_ROOT})",
+    )
+    parser.add_argument(
+        "--worker-config",
+        type=Path,
+        default=DEFAULT_WORKER_CONFIG,
+        help=(
+            "Worker config used to discover the runs root and current Lidskjalv image "
+            f"(default: {DEFAULT_WORKER_CONFIG})"
+        ),
+    )
+    parser.add_argument(
+        "--run-id",
+        help="Override the target run_id. Defaults to the latest run directory.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        choices=base.LIDSKJALV_STEPS,
+        dest="steps",
+        help="Limit retries to a specific lidskjalv step. Repeatable.",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT,
+        help=f"Stable root for standalone replay outputs (default: {DEFAULT_OUTPUT_ROOT})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="List selected retry targets and planned output paths without running Docker.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Replay even if a prior standalone retry already submitted successfully.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    runs_root = base.resolve_runs_root(args.runs_root, args.worker_config)
+    latest_run = resolve_target_run(runs_root, args.run_id)
+    worker_image_ref = current_lidskjalv_image(args.worker_config)
+    steps = tuple(args.steps or base.LIDSKJALV_STEPS)
+    selections = discover_targets_for_run(latest_run, steps)
+    invocation_started_at = base.timestamp_slug()
+    aggregate_entries: list[dict[str, object]] = []
+
+    if not selections:
+        print(f"No failed/error lidskjalv targets matched in run {latest_run.name}.")
+        base.write_invocation_summary(
+            args.output_root,
+            invocation_started_at,
+            runs_root,
+            aggregate_entries,
+        )
+        return 0
+
+    if args.dry_run:
+        for selection in selections:
+            stable_dir = base.stable_step_output_dir(args.output_root, selection)
+            print(
+                f"{selection.run_id}\t{selection.step}\t{selection.status}\t"
+                f"{selection.reason or ''}\t{worker_image_ref}\t{stable_dir}"
+            )
+            aggregate_entries.append(
+                {
+                    "run_id": selection.run_id,
+                    "step": selection.step,
+                    "selector_source": selection.source,
+                    "selected_status": selection.status,
+                    "selected_reason": selection.reason,
+                    "result": "dry-run",
+                    "stable_output_dir": str(stable_dir),
+                    "image_ref_requested": worker_image_ref,
+                    "image_source_requested": "worker_config",
+                }
+            )
+        base.write_invocation_summary(
+            args.output_root,
+            invocation_started_at,
+            runs_root,
+            aggregate_entries,
+        )
+        return 0
+
+    base.require_sonar_env()
+    overall_success = True
+
+    for selection in selections:
+        stable_dir = base.stable_step_output_dir(args.output_root, selection)
+        prior_success = base.load_prior_success(stable_dir)
+        if prior_success is not None and not args.force:
+            print(
+                f"Skipping {selection.run_id} {selection.step}: prior submission success "
+                f"at {prior_success['attempt_dir']}"
+            )
+            aggregate_entries.append(
+                {
+                    "run_id": selection.run_id,
+                    "step": selection.step,
+                    "selector_source": selection.source,
+                    "selected_status": selection.status,
+                    "selected_reason": selection.reason,
+                    "result": "skipped_prior_success",
+                    "stable_output_dir": str(stable_dir),
+                    "attempt_dir": prior_success["attempt_dir"],
+                }
+            )
+            continue
+
+        attempt_dir = stable_dir / f"attempt-{base.timestamp_slug()}"
+        try:
+            context = build_replay_context(selection, worker_image_ref)
+            attempt_entry = base.execute_replay_attempt(
+                attempt_dir=attempt_dir,
+                context=context,
+                output_root=args.output_root,
+            )
+        except Exception as exc:  # pragma: no cover - failure capture
+            overall_success = False
+            error_entry = {
+                "run_id": selection.run_id,
+                "step": selection.step,
+                "selector_source": selection.source,
+                "selected_status": selection.status,
+                "selected_reason": selection.reason,
+                "result": "preflight_failed",
+                "stable_output_dir": str(stable_dir),
+                "attempt_dir": str(attempt_dir),
+                "error": str(exc) or exc.__class__.__name__,
+            }
+            base.ensure_directory(attempt_dir)
+            base.write_json(attempt_dir / "summary.json", error_entry)
+            print(
+                f"Replay preflight failed for {selection.run_id} {selection.step}: "
+                f"{error_entry['error']}",
+                file=sys.stderr,
+            )
+            aggregate_entries.append(error_entry)
+            continue
+
+        aggregate_entries.append(attempt_entry)
+        if attempt_entry["result"] != "submission_success":
+            overall_success = False
+
+    base.write_invocation_summary(
+        args.output_root,
+        invocation_started_at,
+        runs_root,
+        aggregate_entries,
+    )
+    return 0 if overall_success else 1
+
+
+def resolve_target_run(runs_root: Path, run_id: str | None) -> Path:
+    if run_id is not None:
+        run_root = runs_root / run_id
+        if not run_root.is_dir():
+            raise RuntimeError(f"Requested run does not exist: {run_root}")
+        return run_root
+    candidates = sorted(path for path in runs_root.iterdir() if path.is_dir())
+    if not candidates:
+        raise RuntimeError(f"No run directories found under {runs_root}")
+    return candidates[-1]
+
+
+def current_lidskjalv_image(worker_config_path: Path) -> str:
+    config = load_worker_config(worker_config_path)
+    image_ref = config.images.lidskjalv.strip()
+    if not image_ref:
+        raise RuntimeError(
+            f"Worker config does not define images.lidskjalv: {worker_config_path}"
+        )
+    return image_ref
+
+
+def discover_targets_for_run(
+    run_root: Path,
+    steps: tuple[str, ...],
+) -> list[base.StepSelection]:
+    pipeline_report = base.load_optional_json(
+        run_root / "pipeline" / "outputs" / "run_report.json"
+    )
+    results: list[base.StepSelection] = []
+    for step in steps:
+        selection = base.select_step_target(run_root, step, pipeline_report)
+        if selection is not None:
+            results.append(selection)
+    return results
+
+
+def build_replay_context(
+    selection: base.StepSelection,
+    worker_image_ref: str,
+) -> base.ReplayContext:
+    context = base.build_replay_context(selection)
+    return replace(
+        context,
+        requested_image_ref=worker_image_ref,
+        requested_image_source="worker_config",
+        configured_image_ref=worker_image_ref,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/heimdall/sonar_follow_up.py
+++ b/src/heimdall/sonar_follow_up.py
@@ -25,8 +25,12 @@ from heimdall.utils import timestamp_utc, write_text
 SONAR_FOLLOW_UP_SCHEMA_VERSION = "heimdall_sonar_follow_up.v1"
 SONAR_FOLLOW_UP_POLL_INTERVAL_SEC = 30
 SONAR_MEASURE_KEYS = (
-    "bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,"
-    "reliability_rating,security_rating,sqale_rating,ncloc,sqale_index"
+    "bugs,vulnerabilities,code_smells,security_hotspots,files,classes,functions,"
+    "statements,ncloc,sqale_index,duplicated_files,duplicated_lines,"
+    "duplicated_blocks,blocker_violations,critical_violations,major_violations,"
+    "minor_violations,info_violations,coverage,duplicated_lines_density,"
+    "reliability_rating,security_rating,sqale_rating,complexity,"
+    "cognitive_complexity,comment_lines,comment_lines_density"
 )
 _FOLLOW_UP_TERMINAL_STATUSES = {"complete", "failed", "skipped"}
 _FOLLOW_UP_STEPS = (

--- a/tests/test_export_analysis_bundle.py
+++ b/tests/test_export_analysis_bundle.py
@@ -8,13 +8,12 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from tests.helpers import write_file
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
-
-from tests.helpers import write_file
 
 
 def load_script(name: str):

--- a/tests/test_export_analysis_bundle.py
+++ b/tests/test_export_analysis_bundle.py
@@ -1,0 +1,377 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tests.helpers import write_file
+
+
+def load_script(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+EXPORT = load_script("export_analysis_bundle")
+
+
+class ExportAnalysisBundleTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="analysis-export-tests-")
+        self.root = Path(self.tempdir.name)
+        self.runs_root = self.root / "runs"
+        self.sidecar_root = self.root / "sidecar"
+        self.output_dir = self.root / "bundle"
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_bundle_dedupes_only_original_project_keys(self) -> None:
+        codex_run = "20260501T000000Z__owner_repo__abc123"
+        claude_run = "20260502T000000Z__owner_repo__abc123"
+        self._write_run(codex_run, agent_suffix="codex")
+        self._write_run(claude_run, agent_suffix="claude")
+
+        with mock.patch.object(
+            EXPORT.batch_scope,
+            "scoped_run_ids",
+            return_value=[("codex", codex_run), ("claude", claude_run)],
+        ):
+            bundle = EXPORT.build_bundle(
+                runs_root=self.runs_root,
+                sonar_sidecar_root=self.sidecar_root,
+                output_dir=self.output_dir,
+                copy_raw=True,
+            )
+            EXPORT.write_bundle(self.output_dir, bundle)
+
+        self.assertEqual(len(bundle["runs"]), 2)
+        self.assertNotIn("reason", bundle["runs"][0])
+        self.assertEqual(len(bundle["variants"]), 8)
+        original_variants = [
+            row for row in bundle["variants"] if row["variant"] == "original"
+        ]
+        generated_variants = [
+            row for row in bundle["variants"] if row["variant"] == "generated"
+        ]
+        self.assertEqual(
+            {row["project_key"] for row in original_variants},
+            {"owner_repo__original"},
+        )
+        self.assertEqual(len({row["project_key"] for row in generated_variants}), 2)
+        self.assertNotIn("sonar_scope", original_variants[0])
+        self.assertEqual(
+            sum(
+                1
+                for row in bundle["sonar_projects"]
+                if row["project_key"] == "owner_repo__original"
+            ),
+            1,
+        )
+        self.assertTrue((self.output_dir / "tables" / "variants.csv").is_file())
+        runs_header = (
+            (self.output_dir / "tables" / "runs.csv")
+            .read_text(encoding="utf-8")
+            .splitlines()[0]
+        )
+        self.assertNotIn("reason", runs_header.split(","))
+        self.assertTrue(
+            (
+                self.output_dir
+                / "raw"
+                / "runs"
+                / "codex"
+                / codex_run
+                / "pipeline"
+                / "outputs"
+                / "sonar_follow_up.json"
+            ).is_file()
+        )
+        mimir_row = bundle["mimir"][0]
+        self.assertEqual(mimir_row["changed_methods"], 11)
+        self.assertEqual(mimir_row["component_exact_methods"], 0.4)
+        kvasir_row = bundle["kvasir"][0]
+        self.assertEqual(kvasir_row["original_baseline_tests_discovered"], 20)
+        self.assertEqual(kvasir_row["porting_tests_failed"], 1)
+        self.assertEqual(kvasir_row["suite_total"], 6)
+        self.assertEqual(kvasir_row["write_scope_violation_count"], 13)
+        self.assertNotIn("suite_renamed", kvasir_row)
+        self.assertNotIn("comparison_count", mimir_row)
+
+    def _write_run(self, run_id: str, *, agent_suffix: str) -> None:
+        run_root = self.runs_root / run_id
+        write_file(
+            run_root / "pipeline" / "manifest.yaml",
+            "\n".join(
+                [
+                    "version: 1",
+                    f"run_id: {run_id}",
+                    "source:",
+                    "  repo_url: https://github.com/owner/repo.git",
+                    "  commit_sha: abc123",
+                    "",
+                ]
+            ),
+        )
+        write_file(
+            run_root / "pipeline" / "outputs" / "run_report.json",
+            json.dumps(
+                {
+                    "status": "passed",
+                    "reason": None,
+                    "started_at": "2026-05-01T00:00:00Z",
+                    "finished_at": "2026-05-01T00:10:00Z",
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        sonar_steps = {}
+        project_keys = {
+            "original": "owner_repo__original",
+            "generated": f"owner_repo__generated_{agent_suffix}",
+            "v2": f"owner_repo__generated_v2_{agent_suffix}",
+            "v3": f"owner_repo__generated_v3_{agent_suffix}",
+        }
+        for variant, step in {
+            "original": "lidskjalv-original",
+            "generated": "lidskjalv-generated",
+            "v2": "lidskjalv-generated-v2",
+            "v3": "lidskjalv-generated-v3",
+        }.items():
+            project_key = project_keys[variant]
+            scan_label = "generated" if variant == "generated" else variant
+            sonar_steps[step] = {
+                "step": step,
+                "project_key": project_key,
+                "scan_label": scan_label,
+                "sonar_task_id": f"task-{project_key}",
+                "status": "complete",
+                "reason": None,
+                "ce_task_status": "SUCCESS",
+                "quality_gate_status": "OK",
+                "data_status": "complete",
+                "measures": {"coverage": "10.0", "bugs": "1"},
+                "last_checked_at": "2026-05-01T00:20:00Z",
+                "last_error": None,
+            }
+            write_file(
+                run_root / "services" / step / "run" / "outputs" / "run_report.json",
+                json.dumps(
+                    {
+                        "status": "passed",
+                        "reason": None,
+                        "project_key": project_key,
+                        "scan_label": scan_label,
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+        write_file(
+            run_root / "pipeline" / "outputs" / "sonar_follow_up.json",
+            json.dumps(
+                {"run_id": run_id, "status": "complete", "steps": sonar_steps},
+                indent=2,
+            )
+            + "\n",
+        )
+        for variant, mimir_step, kvasir_step in (
+            ("generated", "mimir", "kvasir"),
+            ("v2", "mimir-v2", "kvasir-v2"),
+            ("v3", "mimir-v3", "kvasir-v3"),
+        ):
+            write_file(
+                run_root
+                / "services"
+                / mimir_step
+                / "run"
+                / "outputs"
+                / "run_report.json",
+                json.dumps(
+                    {
+                        "status": "passed",
+                        "comparison_count": 1,
+                        "diagram_comparisons": {
+                            f"andvari_{variant}": {
+                                "exact_similarity": 0.5,
+                                "fuzzy_similarity": 0.6,
+                                "component_scores": {
+                                    "exact": {
+                                        "packages": 0.1,
+                                        "types": 0.2,
+                                        "fields": 0.3,
+                                        "methods": 0.4,
+                                        "relations": 0.5,
+                                    },
+                                    "fuzzy": {
+                                        "matched_type_coverage": 0.6,
+                                        "field_preservation": 0.7,
+                                        "method_preservation": 0.8,
+                                        "relation_preservation": 0.9,
+                                        "name_package_retention": 1.0,
+                                    },
+                                },
+                                "diff_counts": {
+                                    "missing_packages": 1,
+                                    "added_packages": 2,
+                                    "missing_types": 3,
+                                    "added_types": 4,
+                                    "likely_renamed_or_moved_types": 5,
+                                    "missing_fields": 6,
+                                    "added_fields": 7,
+                                    "changed_fields": 8,
+                                    "missing_methods": 9,
+                                    "added_methods": 10,
+                                    "changed_methods": 11,
+                                    "missing_relations": 12,
+                                    "added_relations": 13,
+                                    "changed_relations": 14,
+                                },
+                            }
+                        },
+                        "porting": {
+                            "iterations_used": 2,
+                            "adapter_nonzero_runs": 1,
+                            "execution": {
+                                "tests_discovered": 10,
+                                "tests_executed": 9,
+                                "tests_failed": 1,
+                                "tests_errors": 0,
+                                "tests_skipped": 2,
+                                "junit_reports_found": 3,
+                            },
+                        },
+                        "baselines": {
+                            "original": {
+                                "status": "passed",
+                                "execution": {
+                                    "tests_discovered": 20,
+                                    "tests_executed": 19,
+                                    "tests_failed": 0,
+                                    "tests_errors": 0,
+                                    "tests_skipped": 1,
+                                    "junit_reports_found": 4,
+                                },
+                            },
+                            "generated": {
+                                "status": "passed",
+                                "execution": {
+                                    "tests_discovered": 18,
+                                    "tests_executed": 17,
+                                    "tests_failed": 1,
+                                    "tests_errors": 0,
+                                    "tests_skipped": 0,
+                                    "junit_reports_found": 5,
+                                },
+                            },
+                        },
+                        "diagnostics": {"write_scope": {"violation_count": 13}},
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+            write_file(
+                run_root
+                / "services"
+                / kvasir_step
+                / "run"
+                / "outputs"
+                / "test_port.json",
+                json.dumps(
+                    {
+                        "result": {
+                            "status": "passed",
+                            "reason": None,
+                            "verdict": "equivalent",
+                            "failure_class": None,
+                        },
+                        "evidence": {
+                            "behavioral": {
+                                "junit_report_count": 2,
+                                "failing_case_count": 0,
+                                "failing_case_unique_count": 0,
+                                "failing_case_occurrence_count": 0,
+                            },
+                            "suite_changes": {
+                                "added": 0,
+                                "modified": 1,
+                                "deleted": 2,
+                                "renamed": 3,
+                                "total": 6,
+                            },
+                            "retention": {
+                                "original_snapshot_file_count": 4,
+                                "final_ported_test_file_count": 5,
+                                "retained_original_test_file_count": 6,
+                                "removed_original_test_file_count": 7,
+                                "retention_ratio": 1.0,
+                                "retained_modified_count": 8,
+                                "retained_unchanged_count": 9,
+                                "assertion_line_change_count": 10,
+                                "undocumented_removed_test_count": 11,
+                                "documented_removed_test_count": 12,
+                            },
+                        },
+                        "porting": {
+                            "iterations_used": 2,
+                            "adapter_nonzero_runs": 1,
+                            "execution": {
+                                "tests_discovered": 10,
+                                "tests_executed": 9,
+                                "tests_failed": 1,
+                                "tests_errors": 0,
+                                "tests_skipped": 2,
+                                "junit_reports_found": 3,
+                            },
+                        },
+                        "baselines": {
+                            "original": {
+                                "status": "passed",
+                                "execution": {
+                                    "tests_discovered": 20,
+                                    "tests_executed": 19,
+                                    "tests_failed": 0,
+                                    "tests_errors": 0,
+                                    "tests_skipped": 1,
+                                    "junit_reports_found": 4,
+                                },
+                            },
+                            "generated": {
+                                "status": "passed",
+                                "execution": {
+                                    "tests_discovered": 18,
+                                    "tests_executed": 17,
+                                    "tests_failed": 1,
+                                    "tests_errors": 0,
+                                    "tests_skipped": 0,
+                                    "junit_reports_found": 5,
+                                },
+                            },
+                        },
+                        "diagnostics": {"write_scope": {"violation_count": 13}},
+                    },
+                    indent=2,
+                )
+                + "\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_sonar_follow_up.py
+++ b/tests/test_reconcile_sonar_follow_up.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "reconcile_sonar_follow_up.py"
+)
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tests.helpers import write_file
+
+
+SPEC = importlib.util.spec_from_file_location("reconcile_sonar_follow_up", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class ReconcileSonarFollowUpTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="reconcile-sonar-tests-")
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_discover_target_runs_selects_missing_follow_up_for_passed_submission(
+        self,
+    ) -> None:
+        run_root = self.root / "20260510T154845Z__frohoff_ysoserial__218bcffc"
+        self._write_state(
+            run_root,
+            {
+                "lidskjalv-original": {
+                    "status": "passed",
+                    "report_status": "passed",
+                }
+            },
+        )
+        write_file(
+            run_root
+            / "services"
+            / "lidskjalv-original"
+            / "run"
+            / "outputs"
+            / "run_report.json",
+            json.dumps(
+                {
+                    "status": "passed",
+                    "scan_label": "original",
+                    "project_key": "frohoff_ysoserial__original",
+                    "scan": {"sonar_task_id": "AZ4Xpi0t-sqW6VKAsGUY"},
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        targets = MODULE.discover_target_runs(self.root)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].run_id, run_root.name)
+        self.assertEqual(targets[0].selection_reason, "missing_follow_up")
+
+    def test_process_target_run_backfills_missing_follow_up_and_updates_metrics(
+        self,
+    ) -> None:
+        run_root = (
+            self.root / "20260430T141039Z__ulisesbocchio_jasypt-spring-boot__2243cb80"
+        )
+        self._write_state(
+            run_root,
+            {
+                "lidskjalv-original": {
+                    "status": "skipped",
+                    "reason": "reused-passed-step",
+                    "report_status": "passed",
+                    "report_path": str(
+                        run_root
+                        / "services"
+                        / "lidskjalv-original"
+                        / "run"
+                        / "outputs"
+                        / "run_report.json"
+                    ),
+                }
+            },
+        )
+        write_file(
+            run_root
+            / "services"
+            / "lidskjalv-original"
+            / "run"
+            / "outputs"
+            / "run_report.json",
+            json.dumps(
+                {
+                    "status": "passed",
+                    "scan_label": "original",
+                    "project_key": "ulisesbocchio_jasypt-spring-boot__original",
+                    "scan": {
+                        "sonar_task_id": "AZ3ex2uMRvB3Y6UKUWBL",
+                        "data_status": "pending",
+                        "measures": {},
+                    },
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        with mock.patch(
+            "heimdall.sonar_follow_up._sonar_api_get_json",
+            side_effect=[
+                {"task": {"status": "SUCCESS"}},
+                {"projectStatus": {"status": "OK"}},
+                {
+                    "component": {
+                        "measures": [
+                            {"metric": "bugs", "value": "0"},
+                            {"metric": "coverage", "value": "81.4"},
+                        ]
+                    }
+                },
+            ],
+        ):
+            result = MODULE.process_target_run(
+                MODULE.TargetRun(run_root, "missing_follow_up"),
+                sonar_host_url="https://sonar.example.test",
+                sonar_token="token",
+            )
+
+        follow_up = json.loads(
+            (run_root / "pipeline" / "outputs" / "sonar_follow_up.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertTrue(result["created"])
+        self.assertTrue(result["changed"])
+        self.assertEqual(result["status"], "complete")
+        self.assertEqual(follow_up["status"], "complete")
+        self.assertEqual(
+            follow_up["steps"]["lidskjalv-original"]["measures"]["bugs"], "0"
+        )
+        self.assertEqual(
+            follow_up["steps"]["lidskjalv-original"]["measures"]["coverage"],
+            "81.4",
+        )
+
+    def _write_state(self, run_root: Path, steps: dict[str, dict[str, object]]) -> None:
+        write_file(
+            run_root / "pipeline" / "state.json",
+            json.dumps(
+                {"schema_version": "heimdall_state.v1", "steps": steps}, indent=2
+            )
+            + "\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reconcile_sonar_follow_up.py
+++ b/tests/test_reconcile_sonar_follow_up.py
@@ -8,14 +8,14 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from tests.helpers import write_file
+
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "reconcile_sonar_follow_up.py"
 )
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
-
-from tests.helpers import write_file
 
 
 SPEC = importlib.util.spec_from_file_location("reconcile_sonar_follow_up", MODULE_PATH)

--- a/tests/test_retry_lidskjalv_current_batch.py
+++ b/tests/test_retry_lidskjalv_current_batch.py
@@ -7,14 +7,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.helpers import write_file
+
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "retry_lidskjalv_current_batch.py"
 )
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
-
-from tests.helpers import write_file
 
 
 SPEC = importlib.util.spec_from_file_location(

--- a/tests/test_retry_lidskjalv_current_batch.py
+++ b/tests/test_retry_lidskjalv_current_batch.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "retry_lidskjalv_current_batch.py"
+)
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tests.helpers import write_file
+
+
+SPEC = importlib.util.spec_from_file_location(
+    "retry_lidskjalv_current_batch", MODULE_PATH
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class RetryLidskjalvSelectionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="retry-lidskjalv-tests-")
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_prefers_failed_service_report_over_blocked_pipeline_status(self) -> None:
+        run_root = self.root / "20260507T093724Z__Grt1228_chatgpt-java__ae761b89"
+        write_file(
+            run_root / "pipeline" / "outputs" / "run_report.json",
+            json.dumps(
+                {
+                    "steps": {
+                        "lidskjalv-original": {
+                            "status": "blocked",
+                            "reason": "blocked-by-upstream",
+                        }
+                    }
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        write_file(
+            run_root
+            / "services"
+            / "lidskjalv-original"
+            / "run"
+            / "outputs"
+            / "run_report.json",
+            json.dumps(
+                {
+                    "status": "failed",
+                    "reason": "cli_fallback_failed",
+                    "project_key": "Grt1228_chatgpt-java__original",
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        selection = MODULE.select_step_target(
+            run_root,
+            "lidskjalv-original",
+            MODULE.load_json_file(
+                run_root / "pipeline" / "outputs" / "run_report.json"
+            ),
+        )
+
+        self.assertIsNotNone(selection)
+        assert selection is not None
+        self.assertEqual(selection.source, "service_report")
+        self.assertEqual(selection.status, "failed")
+        self.assertEqual(selection.reason, "cli_fallback_failed")
+        self.assertEqual(selection.project_key, "Grt1228_chatgpt-java__original")
+
+    def test_falls_back_to_pipeline_error_when_service_report_is_missing(self) -> None:
+        run_root = self.root / "20260508T095125Z__macrozheng_mall-tiny__a81ec474"
+        write_file(
+            run_root / "pipeline" / "outputs" / "run_report.json",
+            json.dumps(
+                {
+                    "steps": {
+                        "lidskjalv-original": {
+                            "status": "error",
+                            "reason": "lidskjalv-timeout",
+                        }
+                    }
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        write_file(
+            run_root / "services" / "lidskjalv-original" / "config" / "manifest.yaml",
+            "version: 1\nproject_key: macrozheng_mall-tiny__original\n",
+        )
+
+        selection = MODULE.select_step_target(
+            run_root,
+            "lidskjalv-original",
+            MODULE.load_json_file(
+                run_root / "pipeline" / "outputs" / "run_report.json"
+            ),
+        )
+
+        self.assertIsNotNone(selection)
+        assert selection is not None
+        self.assertEqual(selection.source, "pipeline_report_fallback")
+        self.assertEqual(selection.status, "error")
+        self.assertEqual(selection.reason, "lidskjalv-timeout")
+        self.assertEqual(selection.project_key, "macrozheng_mall-tiny__original")
+
+    def test_generated_step_prefers_ported_repo_with_valid_kvasir_report(self) -> None:
+        run_root = self.root / "20260507T093402Z__19MisterX98_SeedcrackerX__8e18d20d"
+        ported_repo = (
+            run_root
+            / "services"
+            / "kvasir-v3"
+            / "run"
+            / "artifacts"
+            / "ported-tests-repo"
+        )
+        generated_repo = (
+            run_root
+            / "services"
+            / "andvari-v3"
+            / "run"
+            / "artifacts"
+            / "generated-repo"
+        )
+        ported_repo.mkdir(parents=True, exist_ok=True)
+        generated_repo.mkdir(parents=True, exist_ok=True)
+        write_file(
+            run_root / "services" / "kvasir-v3" / "run" / "outputs" / "test_port.json",
+            json.dumps(
+                {"result": {"status": "skipped", "reason": "no-test-files-found"}},
+                indent=2,
+            )
+            + "\n",
+        )
+
+        selected = MODULE.determine_input_repo(run_root, "lidskjalv-generated-v3")
+
+        self.assertEqual(selected, ported_repo)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_retry_lidskjalv_latest_run.py
+++ b/tests/test_retry_lidskjalv_latest_run.py
@@ -7,14 +7,14 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests.helpers import write_file
+
 MODULE_PATH = (
     Path(__file__).resolve().parents[1] / "scripts" / "retry_lidskjalv_latest_run.py"
 )
 SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
-
-from tests.helpers import write_file
 
 
 SPEC = importlib.util.spec_from_file_location("retry_lidskjalv_latest_run", MODULE_PATH)

--- a/tests/test_retry_lidskjalv_latest_run.py
+++ b/tests/test_retry_lidskjalv_latest_run.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "retry_lidskjalv_latest_run.py"
+)
+SRC_ROOT = Path(__file__).resolve().parents[1] / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tests.helpers import write_file
+
+
+SPEC = importlib.util.spec_from_file_location("retry_lidskjalv_latest_run", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class RetryLidskjalvLatestRunTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(
+            prefix="retry-lidskjalv-latest-tests-"
+        )
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_resolve_target_run_defaults_to_latest_directory(self) -> None:
+        (self.root / "20260510T103020Z__repo__aaaa1111").mkdir()
+        latest = self.root / "20260510T103653Z__repo__bbbb2222"
+        latest.mkdir()
+
+        selected = MODULE.resolve_target_run(self.root, None)
+
+        self.assertEqual(selected, latest)
+
+    def test_discover_targets_for_run_limits_to_single_run(self) -> None:
+        older = self.root / "20260510T103020Z__repo__aaaa1111"
+        latest = self.root / "20260510T103653Z__repo__bbbb2222"
+        write_file(
+            older / "pipeline" / "outputs" / "run_report.json",
+            json.dumps(
+                {"steps": {"lidskjalv-original": {"status": "failed"}}}, indent=2
+            )
+            + "\n",
+        )
+        write_file(
+            latest / "pipeline" / "outputs" / "run_report.json",
+            json.dumps(
+                {"steps": {"lidskjalv-generated-v2": {"status": "failed"}}}, indent=2
+            )
+            + "\n",
+        )
+        write_file(
+            latest
+            / "services"
+            / "lidskjalv-generated-v2"
+            / "run"
+            / "outputs"
+            / "run_report.json",
+            json.dumps(
+                {
+                    "status": "failed",
+                    "reason": "cli_fallback_failed",
+                    "project_key": "repo__generated_v2",
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        selections = MODULE.discover_targets_for_run(
+            latest,
+            ("lidskjalv-original", "lidskjalv-generated-v2"),
+        )
+
+        self.assertEqual(len(selections), 1)
+        self.assertEqual(selections[0].run_id, latest.name)
+        self.assertEqual(selections[0].step, "lidskjalv-generated-v2")
+
+    def test_build_replay_context_overrides_image_from_worker_config(self) -> None:
+        run_root = self.root / "20260510T103653Z__repo__bbbb2222"
+        write_file(
+            run_root / "services" / "lidskjalv-original" / "config" / "manifest.yaml",
+            "version: 1\nproject_key: repo__original\n",
+        )
+        write_file(
+            run_root / "pipeline" / "manifest.yaml",
+            "version: 1\nrun_id: x\nsource:\n  repo_url: https://github.com/example/repo.git\n  commit_sha: 0123456789abcdef0123456789abcdef01234567\nimages:\n  brokk: x\n  eitri: x\n  andvari: x\n  mimir: x\n  kvasir: x\n  lidskjalv: old\nlidskjalv:\n  skip_sonar: false\n",
+        )
+        write_file(
+            run_root / "pipeline" / "state.json",
+            json.dumps(
+                {
+                    "steps": {
+                        "lidskjalv-original": {
+                            "configured_image_ref": "ghcr.io/seidr-edu/lidskjalv@sha256:old",
+                            "resolved_image_id": "sha256:old",
+                        }
+                    }
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        (run_root / "services" / "brokk" / "run" / "artifacts" / "original-repo").mkdir(
+            parents=True, exist_ok=True
+        )
+        selection = MODULE.base.StepSelection(
+            run_id=run_root.name,
+            step="lidskjalv-original",
+            source="service_report",
+            status="failed",
+            reason="unknown",
+            project_key="repo__original",
+            run_root=run_root,
+        )
+
+        context = MODULE.build_replay_context(
+            selection,
+            "ghcr.io/seidr-edu/lidskjalv:latest",
+        )
+
+        self.assertEqual(
+            context.requested_image_ref, "ghcr.io/seidr-edu/lidskjalv:latest"
+        )
+        self.assertEqual(context.requested_image_source, "worker_config")
+        self.assertEqual(
+            context.configured_image_ref, "ghcr.io/seidr-edu/lidskjalv:latest"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sonar_resubmission_scripts.py
+++ b/tests/test_sonar_resubmission_scripts.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+from tests.helpers import write_file
+
+
+def load_script(name: str):
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+RESUBMIT = load_script("resubmit_missing_sonar")
+BACKFILL = load_script("backfill_sonar_resubmissions")
+RECOVER = load_script("recover_manual_sonar_submissions")
+
+
+class SonarResubmissionScriptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="sonar-resubmit-tests-")
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_current_batch_scope_is_frozen_to_40_runs_per_agent(self) -> None:
+        self.assertEqual(len(RESUBMIT.CODEX_RUN_IDS), 40)
+        self.assertEqual(len(RESUBMIT.CLAUDE_RUN_IDS), 40)
+
+    def test_discovers_blocked_missing_submission_when_manifest_and_input_exist(
+        self,
+    ) -> None:
+        run_id = "20260513T080251Z__Mojang_brigadier__b5419b18"
+        run_root = self.root / run_id
+        generated_repo = (
+            run_root / "services" / "andvari" / "run" / "artifacts" / "generated-repo"
+        )
+        generated_repo.mkdir(parents=True)
+        write_file(generated_repo / "src" / "Main.java", "class Main {}\n")
+        write_file(
+            run_root / "pipeline" / "outputs" / "sonar_follow_up.json",
+            json.dumps(
+                {
+                    "steps": {
+                        "lidskjalv-generated": {
+                            "scan_label": "generated",
+                            "sonar_task_id": None,
+                            "status": "skipped",
+                            "reason": "blocked-by-upstream",
+                        }
+                    }
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        write_file(
+            run_root / "services" / "lidskjalv-generated" / "config" / "manifest.yaml",
+            "\n".join(
+                [
+                    "version: 1",
+                    f"run_id: {run_id}",
+                    "scan_label: generated",
+                    "project_key: Mojang_brigadier__generated_claude",
+                    "project_name: Mojang/brigadier (generated) claude",
+                    "skip_sonar: false",
+                    "",
+                ]
+            ),
+        )
+
+        targets = RESUBMIT.discover_targets(
+            runs_root=self.root,
+            run_ids=(run_id,),
+            steps=("lidskjalv-generated",),
+        )
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].agent, "claude")
+        self.assertEqual(targets[0].variant, "generated")
+        self.assertEqual(targets[0].project_key, "Mojang_brigadier__generated_claude")
+        self.assertEqual(targets[0].input_repo, generated_repo)
+
+    def test_prior_success_is_idempotent(self) -> None:
+        stable_dir = self.root / "run" / "lidskjalv-original"
+        write_file(
+            stable_dir / "manual-attempt-20260519T000000Z" / "summary.json",
+            json.dumps(
+                {
+                    "submission_success": True,
+                    "sonar_task_id": "task-1",
+                    "attempt_dir": "manual-attempt-20260519T000000Z",
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+
+        prior = RESUBMIT.load_prior_success(stable_dir)
+
+        self.assertIsNotNone(prior)
+        assert prior is not None
+        self.assertEqual(prior["sonar_task_id"], "task-1")
+
+    def test_manual_scanner_args_persist_report_task_metadata(self) -> None:
+        target = RESUBMIT.MissingSonarTarget(
+            agent="codex",
+            run_id="run",
+            step="lidskjalv-original",
+            scan_label="original",
+            variant="original",
+            follow_up_status="failed",
+            follow_up_reason="reason",
+            project_key="demo__original",
+            project_name="demo original",
+            run_root=self.root,
+            manifest_path=self.root / "manifest.yaml",
+            input_repo=self.root / "repo",
+        )
+
+        args = RESUBMIT.manual_scanner_args(target)
+
+        self.assertIn("-Dsonar.working.directory=/usr/src/.scannerwork", args)
+        self.assertIn(
+            "-Dsonar.scanner.metadataFilePath=/usr/src/.scannerwork/report-task.txt",
+            args,
+        )
+
+    def test_public_project_preflight_updates_existing_project(self) -> None:
+        target = RESUBMIT.MissingSonarTarget(
+            agent="codex",
+            run_id="run",
+            step="lidskjalv-original",
+            scan_label="original",
+            variant="original",
+            follow_up_status="failed",
+            follow_up_reason="reason",
+            project_key="demo__original",
+            project_name="demo original",
+            run_root=self.root,
+            manifest_path=self.root / "manifest.yaml",
+            input_repo=self.root / "repo",
+        )
+
+        with (
+            mock.patch.dict(
+                "os.environ",
+                {
+                    "SONAR_HOST_URL": "https://sonar.example.test",
+                    "SONAR_TOKEN": "token",
+                    "SONAR_ORGANIZATION": "org",
+                },
+            ),
+            mock.patch.object(
+                RESUBMIT,
+                "sonar_api_request",
+                side_effect=[
+                    {"ok": True, "json": {"visibility": "private"}},
+                    {"ok": True, "json": {}},
+                ],
+            ) as request,
+        ):
+            result = RESUBMIT.ensure_public_sonar_project(target)
+
+        self.assertEqual(result["status"], "updated_existing")
+        self.assertEqual(
+            request.call_args_list[1].args[1], "/api/projects/update_visibility"
+        )
+        self.assertEqual(request.call_args_list[1].args[2]["visibility"], "public")
+
+    def test_parse_report_task_reads_ce_task_id_and_project_key(self) -> None:
+        report_task = self.root / "report-task.txt"
+        write_file(
+            report_task,
+            "\n".join(
+                [
+                    "projectKey=demo_project",
+                    "serverUrl=https://sonarcloud.io",
+                    "ceTaskId=AZ-task",
+                    "",
+                ]
+            ),
+        )
+
+        parsed = RESUBMIT.parse_report_task(report_task)
+
+        self.assertEqual(parsed["projectKey"], "demo_project")
+        self.assertEqual(parsed["ceTaskId"], "AZ-task")
+
+
+class SonarResubmissionBackfillTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="sonar-backfill-tests-")
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_backfill_builds_sidecar_follow_up_and_metric_exports(self) -> None:
+        run_id = "20260510T103653Z__19MisterX98_SeedcrackerX__8e18d20d"
+        write_file(
+            self.root
+            / run_id
+            / "lidskjalv-original"
+            / "manual-attempt-20260519T000000Z"
+            / "summary.json",
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "step": "lidskjalv-original",
+                    "scan_label": "original",
+                    "variant": "original",
+                    "project_key": "19MisterX98_SeedcrackerX__original",
+                    "project_name": "19MisterX98/SeedcrackerX (original)",
+                    "sonar_task_id": "AZ-task",
+                    "attempt_type": "manual",
+                    "attempt_dir": "/tmp/attempt",
+                    "submission_success": True,
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        successes = BACKFILL.discover_successful_submissions(self.root)
+        paths = BACKFILL.sync_sidecar_follow_up(self.root, successes)
+
+        with mock.patch(
+            "heimdall.sonar_follow_up._sonar_api_get_json",
+            side_effect=[
+                {"task": {"status": "SUCCESS"}},
+                {"projectStatus": {"status": "OK"}},
+                {
+                    "component": {
+                        "measures": [
+                            {"metric": "bugs", "value": "0"},
+                            {"metric": "coverage", "value": "72.5"},
+                        ]
+                    }
+                },
+            ],
+        ):
+            from heimdall.sonar_follow_up import update_sonar_follow_up
+
+            changed = update_sonar_follow_up(
+                paths[0],
+                sonar_host_url="https://sonar.example.test",
+                sonar_token="token",
+            )
+
+        rows = BACKFILL.write_metric_exports(self.root, paths)
+        follow_up = json.loads(paths[0].read_text(encoding="utf-8"))
+
+        self.assertTrue(changed)
+        self.assertEqual(follow_up["status"], "complete")
+        self.assertEqual(rows[0]["bugs"], "0")
+        self.assertEqual(rows[0]["coverage"], "72.5")
+        self.assertTrue((self.root / "metrics.json").is_file())
+        self.assertTrue((self.root / "metrics.csv").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class ManualSonarRecoveryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="sonar-recovery-tests-")
+        self.root = Path(self.tempdir.name)
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def test_discovers_recoverable_manual_submission_from_docker_log(self) -> None:
+        summary_path = self._write_manual_attempt(
+            log_text=(
+                "ANALYSIS SUCCESSFUL\n"
+                "More about the report processing at "
+                "https://sonarcloud.io/api/ce/task?id=AZ4_testTask\n"
+            )
+        )
+
+        results = RECOVER.discover_recoveries(self.root)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["status"], "recoverable")
+        self.assertEqual(results[0]["sonar_task_id"], "AZ4_testTask")
+        self.assertEqual(results[0]["summary_path"], str(summary_path))
+
+    def test_apply_recovery_updates_only_sidecar_summary(self) -> None:
+        summary_path = self._write_manual_attempt(
+            log_text=(
+                "ANALYSIS SUCCESSFUL\n"
+                "More about the report processing at "
+                "https://sonarcloud.io/api/ce/task?id=AZ4_applyTask\n"
+            )
+        )
+
+        RECOVER.apply_recovery(summary_path, "AZ4_applyTask")
+
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+        self.assertEqual(summary["result"], "submission_success")
+        self.assertTrue(summary["submission_success"])
+        self.assertEqual(summary["sonar_task_id"], "AZ4_applyTask")
+        self.assertIsNone(summary["error"])
+        self.assertTrue(summary["recovered_from_docker_log"])
+
+    def test_true_failure_when_log_has_no_successful_analysis(self) -> None:
+        self._write_manual_attempt(log_text="EXECUTION FAILURE\n")
+
+        results = RECOVER.discover_recoveries(self.root)
+
+        self.assertEqual(results[0]["status"], "true_failure")
+        self.assertIsNone(results[0]["sonar_task_id"])
+
+    def _write_manual_attempt(self, *, log_text: str) -> Path:
+        attempt_dir = (
+            self.root
+            / "20260506T082129Z__demo__abc123"
+            / "lidskjalv-original"
+            / "manual-attempt-20260519T000000Z"
+        )
+        summary_path = attempt_dir / "summary.json"
+        docker_log_path = attempt_dir / "docker.log"
+        write_file(
+            summary_path,
+            json.dumps(
+                {
+                    "run_id": "20260506T082129Z__demo__abc123",
+                    "step": "lidskjalv-original",
+                    "project_key": "demo__original",
+                    "result": "manual_submission_failed",
+                    "submission_success": False,
+                    "sonar_task_id": None,
+                    "error": "manual scanner did not emit a matching ceTaskId/projectKey",
+                    "docker_log_path": str(docker_log_path),
+                },
+                indent=2,
+            )
+            + "\n",
+        )
+        write_file(docker_log_path, log_text)
+        return summary_path

--- a/tests/test_sonar_resubmission_scripts.py
+++ b/tests/test_sonar_resubmission_scripts.py
@@ -8,13 +8,12 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
+from tests.helpers import write_file
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
-
-from tests.helpers import write_file
 
 
 def load_script(name: str):


### PR DESCRIPTION
Add scripts for exporting Heimdall analysis bundles, reconciling Sonar follow-up data, resubmitting missing Sonar scans, and retrying Lidskjalv runs.

Expand collected Sonar follow-up metrics so exported analysis includes size, complexity, duplication, severity, reliability, and security measures.

Add tests covering the export bundle, Sonar reconciliation/resubmission helpers, and Lidskjalv retry scripts.